### PR TITLE
Feature/refactor header

### DIFF
--- a/react-app/src/index.scss
+++ b/react-app/src/index.scss
@@ -12,3 +12,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+*:focus {
+  outline: none;
+}

--- a/react-app/src/stories/Alert.js
+++ b/react-app/src/stories/Alert.js
@@ -21,13 +21,16 @@ const StyledAlert = styled.div`
   &.alert-hidden {
     display: block;
     float: right;
-    height: 69px;
+    /* height: 69px; */ // If this is taller than the alert, the header collapse-on-scroll feature will break
+    height: 43px;
     margin-right: 36px;
     text-align: center;
-    width: 62px;
+    /* width: 62px; */
+    width: 44px;
 
     svg.svg--info {
-      padding: 23px 13px 10px 13px;
+      /* padding: 23px 13px 10px 13px; */
+      padding: 0;
     }
     p.p--alert {
       display: none;
@@ -52,23 +55,41 @@ const StyledAlert = styled.div`
     width: 100%;
   }
 
-  button.button--close-alert {
+  button {
     border: none;
     background: none;
     min-height: 44px;
-    margin-left: 10px;
     padding: 0;
     min-width: 44px;
 
-    svg.svg--close {
+    svg {
       color: white;
+    }
+  }
+
+  button.button--close-alert {
+    margin-left: 10px;
+
+    svg.svg--close {
       height: 40px;
       width: 40px;
     }
   }
+
+  button.button--show-alert {
+    height: 100%;
+    width: 100%;
+  }
 `;
 
-function Alert({ alertHidden, index, message, navHidden, onButtonClick }) {
+function Alert({
+  alertHidden,
+  index,
+  message,
+  navHidden,
+  onCloseButtonClick,
+  onOpenButtonClick,
+}) {
   const alertClasses = [];
 
   if (navHidden) {
@@ -83,13 +104,24 @@ function Alert({ alertHidden, index, message, navHidden, onButtonClick }) {
       aria-controls={`button-close-alert-${index}`}
       className={alertClasses.join(" ")}
     >
-      <InfoIcon className="svg--info" />
+      {!navHidden && alertHidden ? (
+        <button
+          aria-label="Show alert message"
+          className="button--show-alert"
+          id={`button-close-alert-${index}`}
+          onClick={onOpenButtonClick}
+        >
+          <InfoIcon className="svg--info" />
+        </button>
+      ) : (
+        <InfoIcon className="svg--info" />
+      )}
       <p className="p--alert">{message}</p>
       <button
         aria-label="Close alert message"
         className="button--close-alert"
         id={`button-close-alert-${index}`}
-        onClick={onButtonClick}
+        onClick={onCloseButtonClick}
       >
         <CloseIcon className="svg--close" />
       </button>

--- a/react-app/src/stories/Alert.js
+++ b/react-app/src/stories/Alert.js
@@ -14,8 +14,27 @@ const StyledAlert = styled.div`
   min-height: 44px;
   width: 100%;
 
-  &.hidden {
+  &.nav-and-alert-hidden {
     display: none;
+  }
+
+  &.alert-hidden {
+    display: block;
+    float: right;
+    height: 69px;
+    margin-right: 36px;
+    text-align: center;
+    width: 62px;
+
+    svg.svg--info {
+      padding: 23px 13px 10px 13px;
+    }
+    p.p--alert {
+      display: none;
+    }
+    button.button--close-alert {
+      display: none;
+    }
   }
 
   svg.svg--info {
@@ -43,7 +62,6 @@ const StyledAlert = styled.div`
     svg.svg--close {
       color: white;
       height: 40px;
-      vertical-align: middle;
       width: 40px;
     }
   }
@@ -56,11 +74,19 @@ function Alert({
   message,
   onButtonClick,
 }) {
+  const alertClasses = [];
+
+  if (navHidden) {
+    alertClasses.push("nav-and-alert-hidden");
+  } else if (!navHidden && alertHidden) {
+    alertClasses.push("alert-hidden");
+  }
+
   return (
     <StyledAlert
       role="alert"
       aria-controls={`button-close-alert-${alertListIndex}`}
-      className={navHidden || alertHidden ? "hidden" : null}
+      className={alertClasses.join(" ")}
     >
       <InfoIcon className="svg--info" />
       <p className="p--alert">{message}</p>

--- a/react-app/src/stories/Alert.js
+++ b/react-app/src/stories/Alert.js
@@ -39,6 +39,11 @@ const StyledAlert = styled.div`
       display: none;
     }
   }
+  @media (max-width: 374px) {
+    &.alert-hidden {
+      margin-right: 0;
+    }
+  }
 
   svg.svg--info {
     min-height: 30px;

--- a/react-app/src/stories/Alert.js
+++ b/react-app/src/stories/Alert.js
@@ -49,6 +49,7 @@ const StyledAlert = styled.div`
     margin: 0;
     padding: 10px 0;
     vertical-align: middle;
+    width: 100%;
   }
 
   button.button--close-alert {
@@ -67,13 +68,7 @@ const StyledAlert = styled.div`
   }
 `;
 
-function Alert({
-  alertListIndex,
-  alertHidden,
-  navHidden,
-  message,
-  onButtonClick,
-}) {
+function Alert({ alertHidden, index, message, navHidden, onButtonClick }) {
   const alertClasses = [];
 
   if (navHidden) {
@@ -85,7 +80,7 @@ function Alert({
   return (
     <StyledAlert
       role="alert"
-      aria-controls={`button-close-alert-${alertListIndex}`}
+      aria-controls={`button-close-alert-${index}`}
       className={alertClasses.join(" ")}
     >
       <InfoIcon className="svg--info" />
@@ -93,7 +88,7 @@ function Alert({
       <button
         aria-label="Close alert message"
         className="button--close-alert"
-        id={`button-close-alert-${alertListIndex}`}
+        id={`button-close-alert-${index}`}
         onClick={onButtonClick}
       >
         <CloseIcon className="svg--close" />

--- a/react-app/src/stories/Alert.js
+++ b/react-app/src/stories/Alert.js
@@ -6,11 +6,12 @@ import { ReactComponent as InfoIcon } from "./assets/ionic-ios-information-circl
 import { ReactComponent as CloseIcon } from "./assets/ionic-md-close.svg";
 
 const StyledAlert = styled.div`
+  align-items: stretch;
   background-color: #5f9cd8;
   color: white;
-  display: block;
+  display: flex;
   font-size: 18px;
-  height: 44px;
+  min-height: 44px;
   width: 100%;
 
   &.hidden {
@@ -18,25 +19,26 @@ const StyledAlert = styled.div`
   }
 
   svg.svg--info {
-    height: 30px;
+    min-height: 30px;
+    min-width: 30px;
     padding: 7px 20px 7px 14px;
     vertical-align: middle;
-    width: 30px;
   }
 
   p.p--alert {
-    display: inline;
+    display: inline-block;
     margin: 0;
+    padding: 10px 0;
     vertical-align: middle;
   }
 
   button.button--close-alert {
     border: none;
     background: none;
-    height: 44px;
+    min-height: 44px;
     margin-left: 10px;
     padding: 0;
-    width: 44px;
+    min-width: 44px;
 
     svg.svg--close {
       color: white;

--- a/react-app/src/stories/Header.js
+++ b/react-app/src/stories/Header.js
@@ -234,6 +234,7 @@ function Header({ title, userSession, alertMessages }) {
             <Alert
               alertHidden={alertHidden}
               key={`alert-${index}`}
+              index={index}
               message={alertMessage.message}
               navHidden={navHidden}
               onButtonClick={hideAlert}

--- a/react-app/src/stories/Header.js
+++ b/react-app/src/stories/Header.js
@@ -13,7 +13,7 @@ import { ReactComponent as HamburgerIcon } from "./assets/bars-solid.svg";
 import { ReactComponent as InfoIcon } from "./assets/ionic-ios-information-circle.svg";
 
 const HeaderStyled = styled.header`
-  background-color: white;
+  background: none;
   position: sticky;
   top: 0;
 
@@ -25,6 +25,7 @@ const HeaderStyled = styled.header`
 
   div.wrapper {
     align-items: center;
+    background-color: white;
     box-shadow: 0px 3px 6px #d6d6d6;
     display: flex;
     height: 80px;
@@ -72,6 +73,12 @@ const HeaderStyled = styled.header`
     margin: 6px 20px;
     min-width: 205px;
     display: inline-block;
+  }
+  @media (max-width: 575px) {
+    div.wrapper > div.div--title > span.span--title {
+      margin: 6px;
+      min-width: unset;
+    }
   }
   &.header--mini {
     div.wrapper > div.div--title > span.span--title {
@@ -191,7 +198,9 @@ function Header({ title, userSession, alertMessages }) {
               ) : (
                 <>
                   <VLogo id="logo" className="logo vlogo" aria-hidden="true" />
-                  <span className="span--title-pipe"></span>
+                  <MediaQuery minWidth={575}>
+                    <span className="span--title-pipe"></span>
+                  </MediaQuery>
                   <span className="span--title">{title}</span>
                 </>
               )}

--- a/react-app/src/stories/Header.js
+++ b/react-app/src/stories/Header.js
@@ -154,7 +154,7 @@ function Header({ title, userSession, alertMessages }) {
     });
   }
 
-  function showAlert(event) {
+  function showAlertAndNav() {
     setNavHidden(() => {
       return false;
     });
@@ -206,9 +206,7 @@ function Header({ title, userSession, alertMessages }) {
             <button
               aria-label="Open the navigation menu"
               id="menu-icon"
-              onClick={(e) => {
-                toggleNav(e);
-              }}
+              onClick={toggleNav}
             >
               <HamburgerIcon />
             </button>
@@ -216,9 +214,7 @@ function Header({ title, userSession, alertMessages }) {
               <button
                 aria-label="Open the navigation menu and show alert"
                 id="info-icon"
-                onClick={(e) => {
-                  showAlert(e);
-                }}
+                onClick={showAlertAndNav}
               >
                 <InfoIcon />
               </button>
@@ -237,7 +233,8 @@ function Header({ title, userSession, alertMessages }) {
               index={index}
               message={alertMessage.message}
               navHidden={navHidden}
-              onButtonClick={hideAlert}
+              onCloseButtonClick={hideAlert}
+              onOpenButtonClick={showAlertAndNav}
             />
           );
         })}

--- a/react-app/src/stories/Nav.js
+++ b/react-app/src/stories/Nav.js
@@ -71,6 +71,16 @@ const NavStyled = styled.nav`
     font-size: 16px;
     padding-top: 8px;
   }
+  @media (max-width: 374px) {
+    button.button--menu-button {
+      justify-content: center;
+      padding: 0;
+      width: 44px;
+    }
+    button.button--menu-button > span {
+      display: none;
+    }
+  }
 
   @media (max-width: 991px) {
     height: auto;
@@ -107,7 +117,7 @@ function Nav({ hidden, links, toggleSearch }) {
         <UserPanel />
         <LanguagePicker />
       </MediaQuery>
-      <MediaQuery maxWidth={1529}>
+      <MediaQuery maxWidth={1537}>
         <button
           className="button--menu-button"
           onClick={(e) => {


### PR DESCRIPTION
Style updates for responsiveness:
- Alert text can wrap for multi-line support
- Alerts are shown by default on page load
- Alerts can be dismissed to a hidden state and brought back with a click on the "i" icon
- Alerts can be brought back from the collapsed mini Header by using the "i" icon
- Focus styles are turned off globally for demo purposes