### PR TITLE
Refactor/breadcrumbs

### DIFF
--- a/react-app/src/stories/Breadcrumbs.js
+++ b/react-app/src/stories/Breadcrumbs.js
@@ -27,37 +27,22 @@ const StyledBreadcrumb = styled.li`
   display: flex;
   float: left;
   height: 48px;
-  max-width: 224px;
-  padding: 0 18px 0 30px;
+  max-width: 275px;
+  overflow: hidden;
+  /* padding: 0 18px 0 30px; */
 
-  &:first-child {
-    padding-left: 0;
+  span.span--breadcrumb-separator-tail {
+    background-color: transparent;
+    border-left: 10px solid transparent;
+    border-top: 24px solid #fcba19;
+    border-bottom: 24px solid #fcba19;
+    margin-left: 5px;
   }
-  &:last-child {
-    background-color: #fcba19;
-    position: relative;
-  }
-  &:last-child::after {
-    content: "";
-    position: absolute;
-    right: -10px;
-    bottom: 0;
-    width: 0;
-    height: 0;
+  span.span--breadcrumb-separator-arrow {
     border-left: 10px solid #fcba19;
     border-top: 24px solid transparent;
     border-bottom: 24px solid transparent;
-  }
-  &:last-child::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: 0;
-    height: 0;
-    border-left: 10px solid white;
-    border-top: 24px solid transparent;
-    border-bottom: 24px solid transparent;
+    margin-right: 30px;
   }
 
   a,
@@ -65,12 +50,59 @@ const StyledBreadcrumb = styled.li`
     color: #313132;
     text-decoration: none;
   }
+
+  &:first-child {
+    padding-left: 0;
+
+    span.span--breadcrumb-body {
+      max-width: 194px;
+    }
+  }
+
+  &:last-child {
+    padding-right: 0;
+
+    span.span--breadcrumb-tail {
+      background-color: transparent;
+      border-left: 10px solid transparent;
+      border-top: 24px solid #fcba19;
+      border-bottom: 24px solid #fcba19;
+    }
+    span.span--breadcrumb-body {
+      align-items: center;
+      background-color: #fcba19;
+      display: flex;
+      height: 48px;
+      padding: 0 5px;
+    }
+    span.span--breadcrumb-arrow {
+      border-left: 10px solid #fcba19;
+      border-top: 24px solid transparent;
+      border-bottom: 24px solid transparent;
+    }
+  }
 `;
 
 const Breadcrumb = ({ position, href, label, last }) => {
   return (
     <StyledBreadcrumb key={position}>
-      {last ? <span>{label}</span> : <a href={href}>{label}</a>}
+      {position !== 0 && <span class="span--breadcrumb-tail"></span>}
+      <span className="span--breadcrumb-body">
+        {last ? (
+          <span className="span--breadcrumb-label">{label}</span>
+        ) : (
+          <a className="a--breadcrumb-body" href={href}>
+            {label}
+          </a>
+        )}
+      </span>
+      <span class="span--breadcrumb-arrow" />
+      {!last && (
+        <>
+          <span class="span--breadcrumb-separator-tail" />
+          <span class="span--breadcrumb-separator-arrow" />
+        </>
+      )}
     </StyledBreadcrumb>
   );
 };

--- a/react-app/src/stories/Breadcrumbs.js
+++ b/react-app/src/stories/Breadcrumbs.js
@@ -27,10 +27,17 @@ const StyledBreadcrumb = styled.li`
   display: flex;
   float: left;
   height: 48px;
-  max-width: 275px;
+  max-width: 320px;
   overflow: hidden;
   /* padding: 0 18px 0 30px; */
 
+  span.span--breadcrumb-tail {
+    margin-left: 20px;
+  }
+  span.span--breadcrumb-body {
+    min-width: 200px;
+    width: min-content;
+  }
   span.span--breadcrumb-separator-tail {
     background-color: transparent;
     border-left: 10px solid transparent;
@@ -42,7 +49,6 @@ const StyledBreadcrumb = styled.li`
     border-left: 10px solid #fcba19;
     border-top: 24px solid transparent;
     border-bottom: 24px solid transparent;
-    margin-right: 30px;
   }
 
   a,
@@ -73,7 +79,7 @@ const StyledBreadcrumb = styled.li`
       background-color: #fcba19;
       display: flex;
       height: 48px;
-      padding: 0 5px;
+      padding: 0 20px;
     }
     span.span--breadcrumb-arrow {
       border-left: 10px solid #fcba19;
@@ -83,7 +89,7 @@ const StyledBreadcrumb = styled.li`
   }
 `;
 
-const Breadcrumb = ({ position, href, label, last }) => {
+const Breadcrumb = ({ position, href, label, last, needsSeparator }) => {
   return (
     <StyledBreadcrumb key={position}>
       {position !== 0 && <span class="span--breadcrumb-tail"></span>}
@@ -97,7 +103,7 @@ const Breadcrumb = ({ position, href, label, last }) => {
         )}
       </span>
       <span class="span--breadcrumb-arrow" />
-      {!last && (
+      {needsSeparator && (
         <>
           <span class="span--breadcrumb-separator-tail" />
           <span class="span--breadcrumb-separator-arrow" />
@@ -109,6 +115,11 @@ const Breadcrumb = ({ position, href, label, last }) => {
 
 function Breadcrumbs({ breadcrumbs }) {
   const last = breadcrumbs.length - 1;
+  const needsSeparator = [];
+
+  if (breadcrumbs.length > 2) {
+    needsSeparator.push(0);
+  }
 
   return (
     <StyledBreadcrumbs>
@@ -118,6 +129,7 @@ function Breadcrumbs({ breadcrumbs }) {
           href={href}
           label={label}
           last={index === last}
+          needsSeparator={needsSeparator.indexOf(index) !== -1}
         />
       ))}
     </StyledBreadcrumbs>


### PR DESCRIPTION
This PR adds visual arrowheads and tails to Breadcrumb components such that:
- The first Breadcrumb has no tail
- Non-terminal Breadcrumbs in the list are separated visually by gold compressed arrow/tail chevrons
- The final Breadcrumb appears gold and with a tail that's partially translucent
- Positioning is fixed so Breadcrumbs do not appear above the Header when scrolling