### PR TITLE
Add core-js as a direct dependency and import symbol from it for IE

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.1",
     "@testing-library/user-event": "^12.2.0",
+    "core-js": "^3.7.0",
     "node-sass": "^4.14.1",
     "react": "^17.0.1",
     "react-app-polyfill": "^2.0.0",

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -1,5 +1,6 @@
 import "react-app-polyfill/ie11";
 import "react-app-polyfill/stable";
+import "core-js/features/symbol";
 import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";


### PR DESCRIPTION
Fixes #16.

The [ES6 primitive Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) is included from `core-js` in [`react-app-polyfill/ie11`](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/ie11.js#L29) which [we are using](https://github.com/ty2k/bc-gng-prototype/blob/master/react-app/src/index.js#L1).

However, adding `core-js` as a direct dependency and importing it after the `react-app-polyfill` imports in `index.js` makes the app "just work" in IE11 again.

This should not be necessary, but I can't justify the time spent figuring out why `react-app-polyfill` isn't working as expected.