### PR TITLE
Add Employment Standards page

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -12,6 +12,7 @@ import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
 import EmploymentBusinessAndEconomicDevelopment from "./pages/Themes/Employment-Business-and-Economic-Development";
 import EmploymentStandardsAndWorkplaceSafety from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety";
+import EmploymentStandards from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards";
 import News from "./pages/News";
 import PublicEngagements from "./pages/PublicEngagements";
 import JobsHR from "./pages/JobsHR";
@@ -52,6 +53,23 @@ function App() {
         title={""}
         breadcrumbs={[{ href: "/themes", label: "Themes" }]}
         content={<HousingAndTenancy />}
+      />
+      <PrivateRoute
+        exact
+        path="/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
+        title={""}
+        breadcrumbs={[
+          { href: "/themes", label: "Themes" },
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment Standards & Workplace Safety",
+          },
+        ]}
+        content={<EmploymentStandards />}
       />
       <PrivateRoute
         exact

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -62,6 +62,11 @@ const Card = styled.div`
       margin: 10px 0;
     }
   }
+
+  svg {
+    height: 1em;
+    padding-left: 5px;
+  }
 `;
 
 function Icon({ id }) {
@@ -104,7 +109,16 @@ function Navigation({ search, sections }) {
                                 <li
                                   key={`section-${index}-card-${cardIndex}-li-${linkIndex}`}
                                 >
-                                  <Link to={link.href}>{link.label}</Link>
+                                  {link.external ? (
+                                    <>
+                                      <a href={link}>{link.label}</a>
+                                      <Icon
+                                        id={"external-link-alt-solid.svg"}
+                                      />
+                                    </>
+                                  ) : (
+                                    <Link to={link.href}>{link.label}</Link>
+                                  )}
                                 </li>
                               );
                             })}

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -29,7 +29,7 @@ const Section = styled.div`
   }
 `;
 
-const Card = styled.div`
+const StyledCard = styled.div`
   border: 1px solid #d1d1d1;
   padding: 16px;
 
@@ -69,6 +69,18 @@ const Card = styled.div`
   }
 `;
 
+const StyledCardAnchorLink = styled.a`
+  color: inherit;
+  display: flex;
+  text-decoration: inherit;
+`;
+
+const StyledCardRouterLink = styled(Link)`
+  color: inherit;
+  display: flex;
+  text-decoration: inherit;
+`;
+
 function Icon({ id }) {
   const Icon = imageService.getSvg(id);
 
@@ -76,6 +88,70 @@ function Icon({ id }) {
     return <Icon />;
   } else {
     return null;
+  }
+}
+
+function CardAnchorLink({ href, children }) {
+  return <StyledCardAnchorLink href={href}>{children}</StyledCardAnchorLink>;
+}
+
+function CardRouterLink({ href, children }) {
+  return <StyledCardRouterLink to={href}>{children}</StyledCardRouterLink>;
+}
+function Card({ icon, title, description, links, cardLink }) {
+  if (cardLink && cardLink.external === true) {
+    return (
+      <CardAnchorLink href={cardLink.href}>
+        <StyledCard>
+          <div className="card--icon-title">
+            {icon && <Icon id={icon} />}
+            {title && <h3>{title}</h3>}
+            <Icon id="external-link-alt-solid.svg" />
+          </div>
+          {description && <p>{description}</p>}
+        </StyledCard>
+      </CardAnchorLink>
+    );
+  } else if (cardLink && cardLink.external === false) {
+    return (
+      <CardRouterLink href={cardLink.href}>
+        <StyledCard>
+          <div className="card--icon-title">
+            {icon && <Icon id={icon} />}
+            {title && <h3>{title}</h3>}
+          </div>
+          {description && <p>{description}</p>}
+        </StyledCard>
+      </CardRouterLink>
+    );
+  } else {
+    return (
+      <StyledCard>
+        <div className="card--icon-title">
+          {icon && <Icon id={icon} />}
+          {title && <h3>{title}</h3>}
+        </div>
+        {description && <p>{description}</p>}
+        {links && links.length > 0 && (
+          <ul>
+            {links.map((link, index) => {
+              return (
+                <li key={`li-${index}`}>
+                  {link.external ? (
+                    <>
+                      <a href={link}>{link.label}</a>
+                      <Icon id={"external-link-alt-solid.svg"} />
+                    </>
+                  ) : (
+                    <Link to={link.href}>{link.label}</Link>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </StyledCard>
+    );
   }
 }
 
@@ -96,35 +172,10 @@ function Navigation({ search, sections }) {
                   section.cards.length > 0 &&
                   section.cards.map((card, cardIndex) => {
                     return (
-                      <Card key={`section-${index}-card-${cardIndex}`}>
-                        <div className="card--icon-title">
-                          {card.icon && <Icon id={card.icon} />}
-                          {card.title && <h3>{card.title}</h3>}
-                        </div>
-                        {card.description && <p>{card.description}</p>}
-                        {card.links && card.links.length > 0 && (
-                          <ul>
-                            {card.links.map((link, linkIndex) => {
-                              return (
-                                <li
-                                  key={`section-${index}-card-${cardIndex}-li-${linkIndex}`}
-                                >
-                                  {link.external ? (
-                                    <>
-                                      <a href={link}>{link.label}</a>
-                                      <Icon
-                                        id={"external-link-alt-solid.svg"}
-                                      />
-                                    </>
-                                  ) : (
-                                    <Link to={link.href}>{link.label}</Link>
-                                  )}
-                                </li>
-                              );
-                            })}
-                          </ul>
-                        )}
-                      </Card>
+                      <Card
+                        key={`section-${index}-card-${cardIndex}`}
+                        {...card}
+                      />
                     );
                   })}
               </Section>
@@ -134,6 +185,26 @@ function Navigation({ search, sections }) {
     </>
   );
 }
+
+Icon.propTypes = {
+  id: propTypes.string,
+};
+Card.propTypes = {
+  title: propTypes.string,
+  description: propTypes.string,
+  links: propTypes.arrayOf(
+    propTypes.shape({
+      href: propTypes.string,
+      label: propTypes.string,
+    })
+  ),
+  cardLink: propTypes.shape({
+    href: propTypes.string,
+    external: propTypes.bool,
+  }),
+};
+
+Card.defaultProps = {};
 
 Navigation.propTypes = {
   search: propTypes.shape({

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -1,0 +1,192 @@
+const sections = [
+  {
+    title: "How can we help you?",
+    cards: [
+      {
+        title: "Hiring Employees",
+        links: [
+          {
+            href: "/",
+            label: "Domesic workers",
+          },
+          {
+            href: "/",
+            label: "Farm Workers",
+          },
+          {
+            href: "/",
+            label: "Siviculture Workers",
+          },
+          {
+            href: "/",
+            label: "Temporary Foreign Workers",
+          },
+          {
+            href: "/",
+            label: "Young People",
+          },
+        ],
+      },
+      {
+        title: "Hours of Work & Overtime",
+        links: [
+          {
+            href: "/",
+            label: "Overtime Pay",
+          },
+          {
+            href: "/",
+            label: "Averaging Agreements",
+          },
+          {
+            href: "/",
+            label: "Variances",
+          },
+        ],
+      },
+      {
+        title: "Statutory Holidays",
+        links: [
+          {
+            href: "/",
+            label: "Quality for statutory holiday pay",
+          },
+          {
+            href: "/",
+            label: "Calculate statuary holiday pay",
+          },
+        ],
+      },
+      {
+        title: "Taking Time Off",
+        links: [
+          {
+            href: "/",
+            label: "Annual Vacation",
+          },
+          {
+            href: "/",
+            label: "Leaves of absence",
+          },
+          {
+            href: "/",
+            label: "Unexpected time off",
+          },
+          {
+            href: "/",
+            label: "Handling absences & other disruptions",
+          },
+        ],
+      },
+      {
+        title: "Quit, Fired or Laid Off",
+        links: [
+          {
+            href: "/",
+            label: "Quitting or Getting Fired",
+          },
+          {
+            href: "/",
+            label: "Temporary Layoffs",
+          },
+          {
+            href: "/",
+            label: "Extend a COVID-19 temporary layoff",
+          },
+        ],
+      },
+      {
+        title: "Getting Paid for Work",
+        links: [
+          {
+            href: "/",
+            label: "Minimum wage",
+          },
+          {
+            href: "/",
+            label: "Minimum wage daily pay",
+          },
+          {
+            href: "/",
+            label: "Deductions",
+          },
+          {
+            href: "/",
+            label: "Keeping records",
+          },
+          {
+            href: "/",
+            label: "Tips and gratuities",
+          },
+          {
+            href: "/",
+            label: "Uniforms & Special clothing",
+          },
+        ],
+      },
+      {
+        title: "Forms & Resources",
+        links: [
+          {
+            href: "/",
+            label: "Guide to the Employment Standards Act and Regulation",
+          },
+          {
+            href: "/",
+            label: "Education Seminars",
+          },
+          {
+            href: "/",
+            label: "Due diligence searches",
+          },
+        ],
+      },
+      {
+        title: "Specific Industries",
+        description:
+          "Find guidance, standards and regulations based on the industry and type of worker",
+      },
+      {
+        title: "Licensing",
+        links: [
+          {
+            href: "/",
+            label: "Employment agencies",
+          },
+          {
+            href: "/",
+            label: "Talent agencies",
+          },
+          {
+            href: "/",
+            label: "Farm labour contractors",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Our Services",
+    cards: [
+      {
+        title: "Make a Complaint",
+        description: "Submit a complaint to resolve a problem at work",
+      },
+      {
+        title: "Ask a Question",
+        description:
+          "Ask a question or get help with an issue you’re having at work.",
+      },
+      {
+        title: "Register a Domestic Worker",
+        description: "Follow the steps in registering a domestic worker",
+      },
+      {
+        title: "Apply for a temporary foreign worker recruiter’s license",
+        description: "Follow the steps to apply for a recruiter’s license",
+      },
+    ],
+  },
+];
+
+module.exports = sections;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
@@ -1,0 +1,23 @@
+import React from "react";
+import propTypes from "prop-types";
+
+import Navigation from "../../../../../components/Navigation";
+import data from "./data";
+
+function EmploymentStandards() {
+  return (
+    <main>
+      <h1>Employment Standards</h1>
+      <Navigation sections={data} />
+    </main>
+  );
+}
+
+EmploymentStandards.propTypes = {
+  title: propTypes.string,
+  breadcrumbs: propTypes.array,
+};
+
+EmploymentStandards.defaultProps = {};
+
+export default EmploymentStandards;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
@@ -4,6 +4,11 @@ const sections = [
       {
         title: "Employment Standards",
         description: "Find the Employment Standards or seek help or advice",
+        cardLink: {
+          href:
+            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+          external: false,
+        },
       },
       {
         title: "Personal Injury & Workplace Safety",


### PR DESCRIPTION
- Within the Navigation component, individual cards can now act as links, giving us three types of cards:
  1. Cards acting as links pointing externally (`<a>` tag instead of `react-router` Link component)
  2. Cards acting as links pointing internally (`<Link>` component)
  3. Cards that can hold a list of internal or external links
- Add the Employment Standards page, which gets linked from its parent using a card acting as an internal link