### PR TITLE
Refactor Breadcrumbs

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -42,7 +42,6 @@ function App() {
         path="/themes/housing-and-tenancy/residential-tenancies"
         title={""}
         breadcrumbs={[
-          { href: "/themes", label: "Themes" },
           { href: "/themes/housing-and-tenancy", label: "Housing & Tenancy" },
         ]}
         content={<ResidentialTenancies />}
@@ -51,7 +50,7 @@ function App() {
         exact
         path="/themes/housing-and-tenancy"
         title={""}
-        breadcrumbs={[{ href: "/themes", label: "Themes" }]}
+        breadcrumbs={[]}
         content={<HousingAndTenancy />}
       />
       <PrivateRoute
@@ -59,7 +58,6 @@ function App() {
         path="/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
         title={""}
         breadcrumbs={[
-          { href: "/themes", label: "Themes" },
           {
             href: "/themes/employment-business-and-economic-development",
             label: "Employment, Business & Economic Development",
@@ -76,7 +74,6 @@ function App() {
         path="/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety"
         title={""}
         breadcrumbs={[
-          { href: "/themes", label: "Themes" },
           {
             href: "/themes/employment-business-and-economic-development",
             label: "Employment, Business & Economic Development",
@@ -88,7 +85,7 @@ function App() {
         exact
         path="/themes/employment-business-and-economic-development"
         title={""}
-        breadcrumbs={[{ href: "/themes", label: "Themes" }]}
+        breadcrumbs={[]}
         content={<EmploymentBusinessAndEconomicDevelopment />}
       />
       <PrivateRoute

--- a/react-app/src/components/Breadcrumbs.js
+++ b/react-app/src/components/Breadcrumbs.js
@@ -74,6 +74,14 @@ const StyledBreadcrumb = styled.li`
 
     span.span--breadcrumb-body {
       align-items: center;
+      background-color: transparent;
+      display: flex;
+      height: 48px;
+      padding: 0 20px 0 0;
+    }
+
+    span.span--breadcrumb-body-last {
+      align-items: center;
       background-color: #fcba19;
       display: flex;
       height: 48px;
@@ -100,14 +108,14 @@ const Breadcrumb = ({ position, href, label, last, needsDivider }) => {
           <BreadcrumbTail />
         </span>
       )}
-      <span className="span--breadcrumb-body">
-        {last ? (
-          <span className="span--breadcrumb-label">{label}</span>
-        ) : (
-          <a className="a--breadcrumb-body" href={href}>
-            {label}
-          </a>
-        )}
+      <span
+        className={
+          last ? "span--breadcrumb-body-last" : "span--breadcrumb-body"
+        }
+      >
+        <a className="a--breadcrumb-body" href={href}>
+          {label}
+        </a>
       </span>
       {last && (
         <span className="span--breadcrumb-head">
@@ -125,7 +133,7 @@ function Breadcrumbs({ breadcrumbs }) {
   const last = breadcrumbs.length - 1;
   const needsDivider = [];
 
-  if (breadcrumbs.length > 2) {
+  if (breadcrumbs.length === 1 || breadcrumbs.length > 2) {
     needsDivider.push(0);
   }
 
@@ -137,7 +145,7 @@ function Breadcrumbs({ breadcrumbs }) {
           position={index}
           href={href}
           label={label}
-          last={index === last}
+          last={index !== 0 && index === last}
           needsDivider={needsDivider.indexOf(index) !== -1}
         />
       ))}


### PR DESCRIPTION
- Top level verticals like "Themes" don't belong as breadcrumbs as it is extraneous, so this PR removes "Themes" as a breadcrumb
- The Breadcrumbs component is refactored to display the terminal yellow arrow and divider such that:
  1. Single breadcrumb appears white and with the divider after it
  2. Two breadcrumbs don't have the divider, but the terminal breadcrumb is the yellow arrow
  3. Three or more breadcrumbs have dividers between two non-terminal breadcrumbs, and the terminal breadcrumb is yellow