### PR TITLE
NumberedPageNav component

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -8,6 +8,11 @@ import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Services from "./pages/Services";
 import Themes from "./pages/Themes";
+import News from "./pages/News";
+import PublicEngagements from "./pages/PublicEngagements";
+import JobsHR from "./pages/JobsHR";
+import Contact from "./pages/Contact";
+
 import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
 import EmploymentBusinessAndEconomicDevelopment from "./pages/Themes/Employment-Business-and-Economic-Development";
@@ -16,10 +21,7 @@ import EmploymentStandards from "./pages/Themes/Employment-Business-and-Economic
 import HiringEmployees from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees";
 import HiringDomesticWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers";
 import HiringTemporaryForeignWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers";
-import News from "./pages/News";
-import PublicEngagements from "./pages/PublicEngagements";
-import JobsHR from "./pages/JobsHR";
-import Contact from "./pages/Contact";
+import ApplyForRecruitersLicense from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License";
 
 function App() {
   return (
@@ -86,6 +88,43 @@ function App() {
           "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
         }
         parentTitle={"Employment Standards"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-a-recruiters-license"
+        }
+        title={"Apply for a Recuiter’s License"}
+        breadcrumbs={[
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment Standards & Workplace Safety",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+            label: "Employment Standards",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees",
+            label: "Hiring Employees",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers",
+            label: "Hiring Temporary Foreign Workers",
+          },
+        ]}
+        content={<ApplyForRecruitersLicense />}
+        parentHref={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers"
+        }
+        parentTitle={"Hiring Temporary Foreign Workers"}
       />
       <PrivateRoute
         exact

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { Button } from "../components/Button";
 import Callout from "../components/Callout";
+import NumberedPageNav from "../components/NumberedPageNav";
 import OnThisPage from "../components/OnThisPage";
 
 function sanitize(input) {
@@ -147,6 +148,13 @@ function buildHtmlElement(
         <Callout key={`${type}-${index}-${childIndex ? childIndex : null}`}>
           {children}
         </Callout>
+      );
+    case "numbered-page-nav":
+      return (
+        <NumberedPageNav
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          children={children}
+        />
       );
     case "on-this-page":
       return (

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -68,6 +68,8 @@ function buildHtmlElement(
       );
     case "br":
       return <br key={`${type}-${index}`} />;
+    case "hr":
+      return <hr />;
     case "h1":
       return (
         <h1

--- a/react-app/src/components/Callout.js
+++ b/react-app/src/components/Callout.js
@@ -6,7 +6,7 @@ import { textService } from "../_services/text.service";
 
 const StyledDiv = styled.div`
   border-left: 6px solid #fcba19;
-  margin: 48px 0;
+  margin: 20px 0;
   padding: 0 0 0 16px;
 `;
 

--- a/react-app/src/components/Content.js
+++ b/react-app/src/components/Content.js
@@ -11,6 +11,10 @@ const StyledContent = styled.div`
     margin-bottom: 4px;
   }
 
+  hr {
+    border-top: 1px solid #707070;
+  }
+
   p.p--last-updated {
     color: #888888;
     font-size: 16px;

--- a/react-app/src/components/NumberedPageNav.js
+++ b/react-app/src/components/NumberedPageNav.js
@@ -1,0 +1,80 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import styled from "styled-components";
+
+const StyledGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  margin: 20px 0;
+  max-height: 210px;
+`;
+
+const StyledNavTab = styled.div`
+  align-items: center;
+  display: flex;
+  margin: 5px 0;
+
+  a {
+    align-items: center;
+    color: #313132;
+    display: flex;
+    font-weight: 700;
+    min-height: 44px;
+    text-decoration: none;
+
+    // FontAwesome chevron-right-solid to indicate a page that can be opened
+    span.span--navtab-chevron {
+      content: "";
+      background-image: url(data:image/svg+xml;base64,PHN2ZyBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSIgZGF0YS1wcmVmaXg9ImZhcyIgZGF0YS1pY29uPSJjaGV2cm9uLXJpZ2h0IiBjbGFzcz0ic3ZnLWlubGluZS0tZmEgZmEtY2hldnJvbi1yaWdodCBmYS13LTEwIiByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDMyMCA1MTIiPjxwYXRoIGZpbGw9IiMzMTMxMzIiIGQ9Ik0yODUuNDc2IDI3Mi45NzFMOTEuMTMyIDQ2Ny4zMTRjLTkuMzczIDkuMzczLTI0LjU2OSA5LjM3My0zMy45NDEgMGwtMjIuNjY3LTIyLjY2N2MtOS4zNTctOS4zNTctOS4zNzUtMjQuNTIyLS4wNC0zMy45MDFMMTg4LjUwNSAyNTYgMzQuNDg0IDEwMS4yNTVjLTkuMzM1LTkuMzc5LTkuMzE3LTI0LjU0NC4wNC0zMy45MDFsMjIuNjY3LTIyLjY2N2M5LjM3My05LjM3MyAyNC41NjktOS4zNzMgMzMuOTQxIDBMMjg1LjQ3NSAyMzkuMDNjOS4zNzMgOS4zNzIgOS4zNzMgMjQuNTY4LjAwMSAzMy45NDF6Ij48L3BhdGg+PC9zdmc+Cg==);
+      background-repeat: no-repeat;
+      background-size: 30px 30px;
+      display: inline-block;
+      height: 30px;
+      min-width: 30px;
+    }
+
+    &.a--navtab-current-page {
+      // FontAwesome chevron-down-solid to indicate an open page
+      span.span--navtab-chevron {
+        content: "";
+        background-image: url(data:image/svg+xml;base64,PHN2ZyBhcmlhLWhpZGRlbj0idHJ1ZSIgZm9jdXNhYmxlPSJmYWxzZSIgZGF0YS1wcmVmaXg9ImZhcyIgZGF0YS1pY29uPSJjaGV2cm9uLWRvd24iIGNsYXNzPSJzdmctaW5saW5lLS1mYSBmYS1jaGV2cm9uLWRvd24gZmEtdy0xNCIgcm9sZT0iaW1nIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48cGF0aCBmaWxsPSIjMzEzMTMyIiBkPSJNMjA3LjAyOSAzODEuNDc2TDEyLjY4NiAxODcuMTMyYy05LjM3My05LjM3My05LjM3My0yNC41NjkgMC0zMy45NDFsMjIuNjY3LTIyLjY2N2M5LjM1Ny05LjM1NyAyNC41MjItOS4zNzUgMzMuOTAxLS4wNEwyMjQgMjg0LjUwNWwxNTQuNzQ1LTE1NC4wMjFjOS4zNzktOS4zMzUgMjQuNTQ0LTkuMzE3IDMzLjkwMS4wNGwyMi42NjcgMjIuNjY3YzkuMzczIDkuMzczIDkuMzczIDI0LjU2OSAwIDMzLjk0MUwyNDAuOTcxIDM4MS40NzZjLTkuMzczIDkuMzcyLTI0LjU2OSA5LjM3Mi0zMy45NDIgMHoiPjwvcGF0aD48L3N2Zz4K);
+      }
+    }
+
+    span.span--navtab-label {
+      display: inline-block;
+      padding-left: 16px;
+    }
+  }
+`;
+
+function NavTab({ label, href, number }) {
+  return (
+    <StyledNavTab>
+      <NavLink exact to={href} activeClassName="a--navtab-current-page">
+        <span className="span--navtab-chevron" />
+        <span className="span--navtab-label">{`${number}. ${label}`}</span>
+      </NavLink>
+    </StyledNavTab>
+  );
+}
+
+function NumberedPageNav({ children }) {
+  return (
+    <StyledGrid>
+      {children.map(({ label, href }, index) => {
+        return (
+          <NavTab
+            key={`tabbed-page-nav-${index}`}
+            label={label}
+            href={href}
+            number={index + 1}
+          />
+        );
+      })}
+    </StyledGrid>
+  );
+}
+
+export default NumberedPageNav;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
@@ -1,0 +1,143 @@
+const content = [
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "numbered-page-nav",
+    children: [
+      {
+        label: "Overview",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers",
+      },
+      {
+        label: "How to Apply",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-temporary-foreign-worker-recruiters-license",
+      },
+      {
+        label: "Pay the Security Bond",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/search-for-registered-employer-or-licensed-recruiter",
+      },
+      {
+        label: "Register to Hire Foreign Workers",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/register-to-hire-foreign-workers",
+      },
+      {
+        label: "Once You Get Your License",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/register-to-hire-foreign-workers",
+      },
+      {
+        label: "Renewing Your License",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/register-to-hire-foreign-workers",
+      },
+    ],
+  },
+  {
+    type: "button",
+    children: "Apply Online",
+    onClick: null,
+    primary: true,
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "hr",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Recruiters help employers in B.C. find foreign workers. Individual recruiters must be licensed in B.C., even if their business or main operations are located outside of the province. Businesses or organizations that offer recruitment services do not get licensed – only individuals are licensed.",
+      },
+    ],
+  },
+  {
+    type: "callout",
+    children: [
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            style: "strong",
+            children:
+              "Recruiters who operate without a licence could be fined up to $10,000.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "The ",
+      },
+      {
+        type: "a-internal",
+        href: "",
+        children: "federal Temporary Foreign Worker (TFW)",
+      },
+      {
+        type: "text",
+        children:
+          " Program allows people from other countries to be hired for positions when there are no Canadian workers available.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "In B.C., recruiters and employers are regulated under the ",
+      },
+      {
+        type: "a-internal",
+        href: "",
+        children: "Temporary Foreign Worker Protection Act",
+      },
+      {
+        type: "text",
+        children: " to protect against unfair practices.",
+      },
+    ],
+  },
+];
+
+// const wizard = {
+//   title: "Is a Recruiter's License for you?",
+//   first: "intro",
+//   steps: {
+//     intro: {
+//       text:
+//         "In some cases, a recruiter’s license is not necessary for you. Go through this simple questionnaire to see whether or not a recruiter’s license is for you.",
+//       controls: {
+//         forward: {
+//           label: "Start the questionnaire",
+//           step: "",
+//           primary: true,
+//         },
+//       },
+//     },
+//   },
+// };
+
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
@@ -1,0 +1,21 @@
+import React from "react";
+import propTypes from "prop-types";
+
+import Content from "../../../../../../../../components/Content";
+import { Wizard } from "../../../../../../../../components/Wizard";
+import { content } from "./data";
+
+function ApplyForRecruitersLicense() {
+  return (
+    <>
+      <Content content={content} />
+      {/* <Wizard wizard={wizard} /> */}
+    </>
+  );
+}
+
+ApplyForRecruitersLicense.propTypes = {};
+
+ApplyForRecruitersLicense.defaultProps = {};
+
+export default ApplyForRecruitersLicense;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
@@ -73,7 +73,7 @@ const navigation = [
   {
     label: "Apply for a temporary foreign worker recruiter’s license",
     href:
-      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-recruiters-license",
+      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-a-recruiters-license",
   },
   {
     label: "Search for a registered employer or a licensed recruiter",

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/data.js
@@ -113,6 +113,9 @@ const content = [
     ],
   },
   {
+    type: "br",
+  },
+  {
     type: "callout",
     children: [
       {
@@ -126,6 +129,9 @@ const content = [
         ],
       },
     ],
+  },
+  {
+    type: "br",
   },
   {
     type: "p",


### PR DESCRIPTION
This pull request adds the NumberedPageNav component, which is very similar to the TabbedPageNav component except that it organizes nav steps into vertical columns where steps go down and then wrap (versus across and then wrapping). It might be worth forcing these two components together since they're so visually similar.

Also:
- `<hr/>` added to `buildHtmlElement()` in text service
- Margin adjustment in Callout component
- ESB "Apply For a Recruiter's License" page added