### PR TITLE
Cleanup unused propTypes and update imports

### DIFF
--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -5,6 +5,7 @@ import { Button } from "../components/Button";
 import Callout from "../components/Callout";
 import NumberedPageNav from "../components/NumberedPageNav";
 import OnThisPage from "../components/OnThisPage";
+import Wizard from "../components/Wizard";
 
 function sanitize(input) {
   return DOMPurify.sanitize(input);
@@ -21,13 +22,15 @@ function sanitize(input) {
  *                           or an array for composed elements
  *                           like `p`, `span`, or React components
  *   - @param {string} title - title for React components
+ *   - @param {string} first - ID of the first step in stepped component
+ *   - @param {object} steps - JSON representation of steps in stepped component
  *   - @param {string} href - the `href` of an `a` tag, the `to` of a Link
  *   - @param {Boolean} primary - primary Boolean for Button components
  * @param {number} index - array index for React keys if applicable
  * @param {number} childIndex - nested array index for React keys if applicable
  */
 function buildHtmlElement(
-  { type, id, style, className, children, title, href, primary },
+  { type, id, style, className, children, title, first, steps, href, primary },
   index = null,
   childIndex = null
 ) {
@@ -171,6 +174,8 @@ function buildHtmlElement(
           title={title}
         />
       );
+    case "wizard":
+      return <Wizard first={first} steps={steps} title={title} />;
     default:
       return null;
   }

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -5,7 +5,6 @@ import styled from "styled-components";
 
 import { imageService } from "../_services/image.service";
 import SearchBar from "./SearchBar";
-import { Wizard } from "./Wizard";
 
 const Section = styled.div`
   margin: 30px 0 50px 0;
@@ -157,10 +156,9 @@ function Card({ icon, title, description, links, cardLink }) {
   }
 }
 
-function Navigation({ search, sections, wizard }) {
+function Navigation({ search, sections }) {
   return (
     <>
-      {wizard && <Wizard {...wizard} />}
       {search && <SearchBar placeHolder={search.label || "Search"} />}
       {sections &&
         sections.length > 0 &&

--- a/react-app/src/components/Wizard.js
+++ b/react-app/src/components/Wizard.js
@@ -91,7 +91,7 @@ const StyledWizard = styled.div`
   }
 `;
 
-export function Wizard({ title, tree, first, steps }) {
+function Wizard({ title, first, steps }) {
   const [stepsShown, setStepsShown] = useState([first]);
   const [data, setData] = useState({});
   const [explanation, setExplanation] = useState("");
@@ -246,3 +246,5 @@ export function Wizard({ title, tree, first, steps }) {
     </StyledWizard>
   );
 }
+
+export default Wizard;

--- a/react-app/src/pages/Contact/index.js
+++ b/react-app/src/pages/Contact/index.js
@@ -1,15 +1,7 @@
 import React from "react";
-import propTypes from "prop-types";
 
 function Contact() {
   return <p>Contact us page</p>;
 }
-
-Contact.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-Contact.defaultProps = {};
 
 export default Contact;

--- a/react-app/src/pages/Home/index.js
+++ b/react-app/src/pages/Home/index.js
@@ -1,15 +1,7 @@
 import React from "react";
-import propTypes from "prop-types";
 
 function Home() {
   return <p>Province of British Columbia</p>;
 }
-
-Home.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-Home.defaultProps = {};
 
 export default Home;

--- a/react-app/src/pages/JobsHR/index.js
+++ b/react-app/src/pages/JobsHR/index.js
@@ -1,15 +1,7 @@
 import React from "react";
-import propTypes from "prop-types";
 
 function JobsHR() {
   return <p>Jobs &amp; HR page</p>;
 }
-
-JobsHR.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-JobsHR.defaultProps = {};
 
 export default JobsHR;

--- a/react-app/src/pages/News/index.js
+++ b/react-app/src/pages/News/index.js
@@ -1,15 +1,7 @@
 import React from "react";
-import propTypes from "prop-types";
 
 function News() {
   return <p>News page</p>;
 }
-
-News.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-News.defaultProps = {};
 
 export default News;

--- a/react-app/src/pages/PublicEngagements/index.js
+++ b/react-app/src/pages/PublicEngagements/index.js
@@ -1,15 +1,7 @@
 import React from "react";
-import propTypes from "prop-types";
 
 function PublicEngagements() {
   return <p>Public Engagements page</p>;
 }
-
-PublicEngagements.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-PublicEngagements.defaultProps = {};
 
 export default PublicEngagements;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Content from "../../../../../../../components/Content";
 import TabbedPageNav from "../../../../../../../components/TabbedPageNav";
@@ -14,9 +13,5 @@ function HiringEmployees() {
     </>
   );
 }
-
-HiringEmployees.propTypes = {};
-
-HiringEmployees.defaultProps = {};
 
 export default HiringEmployees;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
@@ -120,24 +120,24 @@ const content = [
       },
     ],
   },
+  {
+    type: "wizard",
+    title: "Is a Recruiter's License for you?",
+    first: "intro",
+    steps: {
+      intro: {
+        text:
+          "In some cases, a recruiter’s license is not necessary for you. Go through this simple questionnaire to see whether or not a recruiter’s license is for you.",
+        controls: {
+          forward: {
+            label: "Start the questionnaire",
+            step: "",
+            primary: true,
+          },
+        },
+      },
+    },
+  },
 ];
-
-// const wizard = {
-//   title: "Is a Recruiter's License for you?",
-//   first: "intro",
-//   steps: {
-//     intro: {
-//       text:
-//         "In some cases, a recruiter’s license is not necessary for you. Go through this simple questionnaire to see whether or not a recruiter’s license is for you.",
-//       controls: {
-//         forward: {
-//           label: "Start the questionnaire",
-//           step: "",
-//           primary: true,
-//         },
-//       },
-//     },
-//   },
-// };
 
 export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Content from "../../../../../../../../components/Content";
 import { content } from "./data";
@@ -7,9 +6,5 @@ import { content } from "./data";
 function ApplyForRecruitersLicense() {
   return <Content content={content} />;
 }
-
-ApplyForRecruitersLicense.propTypes = {};
-
-ApplyForRecruitersLicense.defaultProps = {};
 
 export default ApplyForRecruitersLicense;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
@@ -2,16 +2,10 @@ import React from "react";
 import propTypes from "prop-types";
 
 import Content from "../../../../../../../../components/Content";
-import { Wizard } from "../../../../../../../../components/Wizard";
 import { content } from "./data";
 
 function ApplyForRecruitersLicense() {
-  return (
-    <>
-      <Content content={content} />
-      {/* <Wizard wizard={wizard} /> */}
-    </>
-  );
+  return <Content content={content} />;
 }
 
 ApplyForRecruitersLicense.propTypes = {};

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
@@ -1,5 +1,8 @@
 const content = [
   {
+    type: "br",
+  },
+  {
     type: "p",
     className: "p--last-updated",
     children: [

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Content from "../../../../../../../components/Content";
 import TabbedPageNav from "../../../../../../../components/TabbedPageNav";
@@ -14,9 +13,5 @@ function HiringTemporaryForeignWorkers() {
     </>
   );
 }
-
-HiringTemporaryForeignWorkers.propTypes = {};
-
-HiringTemporaryForeignWorkers.defaultProps = {};
 
 export default HiringTemporaryForeignWorkers;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Content from "../../../../../../components/Content";
 import TabbedPageNav from "../../../../../../components/TabbedPageNav";
@@ -13,9 +12,5 @@ function HiringEmployees() {
     </>
   );
 }
-
-HiringEmployees.propTypes = {};
-
-HiringEmployees.defaultProps = {};
 
 export default HiringEmployees;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -194,117 +194,113 @@ const sections = [
   },
 ];
 
-const wizard = {
-  title: "Do Employment Standards apply to you?",
-  tree: {
-    intro: ["start"],
-    start: ["workplace_safety", "employment_standards"],
-    workplace_safety: ["start", "worksafe_bc"],
-    employment_standards: ["start"],
-    worksafe_bc: ["start"],
-  },
-  first: "intro",
-  steps: {
-    intro: {
-      text:
-        "Not every work issue, workplace or type is related to Employment Standards. We can help direct you to the right place with this quick questionnaire.",
-      controls: {
-        forward: {
-          label: "Start the questionnaire",
-          step: "start",
-          primary: true,
+const content = [
+  {
+    type: "wizard",
+    title: "Do Employment Standards apply to you?",
+    first: "intro",
+    steps: {
+      intro: {
+        text:
+          "Not every work issue, workplace or type is related to Employment Standards. We can help direct you to the right place with this quick questionnaire.",
+        controls: {
+          forward: {
+            label: "Start the questionnaire",
+            step: "start",
+            primary: true,
+          },
         },
       },
-    },
-    start: {
-      question_text:
-        "Please tell us how you would describe your work situation.",
-      options: [
-        {
-          label: "I am an employee",
-          id: "employee",
-          next_step: "workplace_safety",
-          text:
-            "An employee is someone who receives money (or is owed money) for work performed. This includes someone who an employer allows to perform work that would normally be done by an employee.",
-        },
-        {
-          label: "I am an employer",
-          id: "employer",
-          next_step: "employment_standards",
-          text:
-            "An employer is someone who hires employees and is responsible for their employment. They have control over employees or provide instruction and/or direction to staff.",
-        },
-        {
-          label: "I am an independent contractor",
-          id: "contractor",
-          next_step: "workplace_safety",
-          text:
-            "An independent contractor is considered to be self-employed. Contractors are responsible for upholding workplace standards for their business.",
-        },
-      ],
-      controls: {
-        back: {
-          label: "Back",
-          step: "intro",
-        },
-        forward: {
-          label: "Next",
-          primary: true,
-        },
-      },
-    },
-    workplace_safety: {
-      question_text: "Is your question or concern about workplace safety?",
-      options: [
-        {
-          label: "Yes",
-          id: "yes",
-          next_step: "worksafe_bc",
-        },
-        {
-          label: "No",
-          id: "no",
-          next_step: "worksafe_bc",
-        },
-      ],
-      controls: {
-        back: {
-          label: "Back",
-          next_step: "start",
-        },
-        forward: {
-          label: "Next",
-          primary: true,
+      start: {
+        question_text:
+          "Please tell us how you would describe your work situation.",
+        options: [
+          {
+            label: "I am an employee",
+            id: "employee",
+            next_step: "workplace_safety",
+            text:
+              "An employee is someone who receives money (or is owed money) for work performed. This includes someone who an employer allows to perform work that would normally be done by an employee.",
+          },
+          {
+            label: "I am an employer",
+            id: "employer",
+            next_step: "employment_standards",
+            text:
+              "An employer is someone who hires employees and is responsible for their employment. They have control over employees or provide instruction and/or direction to staff.",
+          },
+          {
+            label: "I am an independent contractor",
+            id: "contractor",
+            next_step: "workplace_safety",
+            text:
+              "An independent contractor is considered to be self-employed. Contractors are responsible for upholding workplace standards for their business.",
+          },
+        ],
+        controls: {
+          back: {
+            label: "Back",
+            step: "intro",
+          },
+          forward: {
+            label: "Next",
+            primary: true,
+          },
         },
       },
-    },
-    employment_standards: {
-      text:
-        "Yes, as an employer, Employment Standards apply. Navigate along to learn more about Employment Standards or seek advice.",
-      controls: {
-        back: {
-          label: "Back",
-        },
-        restart: {
-          label: "Restart",
-          primary: true,
+      workplace_safety: {
+        question_text: "Is your question or concern about workplace safety?",
+        options: [
+          {
+            label: "Yes",
+            id: "yes",
+            next_step: "worksafe_bc",
+          },
+          {
+            label: "No",
+            id: "no",
+            next_step: "worksafe_bc",
+          },
+        ],
+        controls: {
+          back: {
+            label: "Back",
+            next_step: "start",
+          },
+          forward: {
+            label: "Next",
+            primary: true,
+          },
         },
       },
-    },
-    worksafe_bc: {
-      text:
-        '<p><a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> is the organization primarily responsible for addressing issues concerning workplace health and safety. This includes injuries, illness, or other health and safety incidents.</p>\r\n<p><strong>You can:</strong></p>\r\n<p>- Visit <a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> to learn about workplace health and safety in B.C., to report an incident or to seek resolution</p>\r\n<p>- Contact the <a href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/personal-injury-and-workplace-safety">Workers\u2019 Advisers Office</a> if you disagree with a WorkSafeBC decision</p>',
-      controls: {
-        back: {
-          label: "Back",
+      employment_standards: {
+        text:
+          "Yes, as an employer, Employment Standards apply. Navigate along to learn more about Employment Standards or seek advice.",
+        controls: {
+          back: {
+            label: "Back",
+          },
+          restart: {
+            label: "Restart",
+            primary: true,
+          },
         },
-        restart: {
-          label: "Restart",
-          primary: true,
+      },
+      worksafe_bc: {
+        text:
+          '<p><a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> is the organization primarily responsible for addressing issues concerning workplace health and safety. This includes injuries, illness, or other health and safety incidents.</p>\r\n<p><strong>You can:</strong></p>\r\n<p>- Visit <a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> to learn about workplace health and safety in B.C., to report an incident or to seek resolution</p>\r\n<p>- Contact the <a href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/personal-injury-and-workplace-safety">Workers\u2019 Advisers Office</a> if you disagree with a WorkSafeBC decision</p>',
+        controls: {
+          back: {
+            label: "Back",
+          },
+          restart: {
+            label: "Restart",
+            primary: true,
+          },
         },
       },
     },
   },
-};
+];
 
-export { sections, wizard };
+export { sections, content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Content from "../../../../../components/Content";
 import Navigation from "../../../../../components/Navigation";
@@ -13,12 +12,5 @@ function EmploymentStandards() {
     </>
   );
 }
-
-EmploymentStandards.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-EmploymentStandards.defaultProps = {};
 
 export default EmploymentStandards;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
@@ -1,11 +1,17 @@
 import React from "react";
 import propTypes from "prop-types";
 
+import Content from "../../../../../components/Content";
 import Navigation from "../../../../../components/Navigation";
-import { sections, wizard } from "./data";
+import { sections, content } from "./data";
 
 function EmploymentStandards() {
-  return <Navigation sections={sections} wizard={wizard} />;
+  return (
+    <>
+      <Content content={content} />
+      <Navigation sections={sections} />
+    </>
+  );
 }
 
 EmploymentStandards.propTypes = {

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
@@ -56,4 +56,4 @@ const sections = [
   },
 ];
 
-module.exports = sections;
+export { sections };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
@@ -1,18 +1,10 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Navigation from "../../../../components/Navigation";
-import data from "./data";
+import { sections } from "./data";
 
 function EmploymentStandardsAndWorkplaceSafety() {
-  return <Navigation sections={data} />;
+  return <Navigation sections={sections} />;
 }
-
-EmploymentStandardsAndWorkplaceSafety.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-EmploymentStandardsAndWorkplaceSafety.defaultProps = {};
 
 export default EmploymentStandardsAndWorkplaceSafety;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
@@ -130,4 +130,4 @@ const sections = [
   },
 ];
 
-module.exports = sections;
+export { sections };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
@@ -1,23 +1,15 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Navigation from "../../../components/Navigation";
-import data from "./data";
+import { sections } from "./data";
 
 function EmploymentBusinessAndEconomicDevelopment() {
   return (
     <Navigation
       search={{ label: "Employment, Business & Economic Development" }}
-      sections={data}
+      sections={sections}
     />
   );
 }
-
-EmploymentBusinessAndEconomicDevelopment.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-EmploymentBusinessAndEconomicDevelopment.defaultProps = {};
 
 export default EmploymentBusinessAndEconomicDevelopment;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
@@ -64,4 +64,4 @@ const sections = [
   },
 ];
 
-module.exports = sections;
+export { sections };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
@@ -1,23 +1,15 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Navigation from "../../../../components/Navigation";
-import data from "./data";
+import { sections } from "./data";
 
 function ResidentialTenancies() {
   return (
     <Navigation
       search={{ label: "Search Residential Tenancies" }}
-      sections={data}
+      sections={sections}
     />
   );
 }
-
-ResidentialTenancies.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-ResidentialTenancies.defaultProps = {};
 
 export default ResidentialTenancies;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
@@ -131,4 +131,4 @@ const sections = [
   },
 ];
 
-module.exports = sections;
+export { sections };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
@@ -1,23 +1,15 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Navigation from "../../../components/Navigation";
-import data from "./data";
+import { sections } from "./data";
 
 function HousingAndTenancy() {
   return (
     <Navigation
       search={{ label: "Search Housing & Tenancy" }}
-      sections={data}
+      sections={sections}
     />
   );
 }
-
-HousingAndTenancy.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-HousingAndTenancy.defaultProps = {};
 
 export default HousingAndTenancy;

--- a/react-app/src/pages/Themes/data.js
+++ b/react-app/src/pages/Themes/data.js
@@ -290,4 +290,4 @@ const sections = [
   },
 ];
 
-module.exports = sections;
+export { sections };

--- a/react-app/src/pages/Themes/index.js
+++ b/react-app/src/pages/Themes/index.js
@@ -1,18 +1,10 @@
 import React from "react";
-import propTypes from "prop-types";
 
 import Navigation from "../../components/Navigation";
-import data from "./data";
+import { sections } from "./data";
 
 function Themes() {
-  return <Navigation search={{ label: "Search Themes" }} sections={data} />;
+  return <Navigation search={{ label: "Search Themes" }} sections={sections} />;
 }
-
-Themes.propTypes = {
-  title: propTypes.string,
-  breadcrumbs: propTypes.array,
-};
-
-Themes.defaultProps = {};
 
 export default Themes;


### PR DESCRIPTION
- Remove unused `propTypes` in content page files. These pages are simple enough that they can be extracted into a generalized router service soon.
- Decouple Wizard component from Navigation component. Instead, use Wizard in the text service's `buildHtmlElement()` function.
- Update data imports in content pages to use multiple import style.