### PR TITLE
Adjust mobile Header styles

### DIFF
--- a/react-app/src/_services/image.service.js
+++ b/react-app/src/_services/image.service.js
@@ -1,4 +1,5 @@
 import { ReactComponent as ambulance } from "../components/assets/ambulance.svg";
+import { ReactComponent as backToTop } from "../components/assets/back-to-top.svg";
 import { ReactComponent as barsSolid } from "../components/assets/bars-solid.svg";
 import { ReactComponent as bcHorizontal } from "../components/assets/BCID_H_rgb_pos.svg";
 import { ReactComponent as bcVertical } from "../components/assets/BCID_V_rgb_pos.svg";
@@ -44,6 +45,7 @@ import { ReactComponent as searchSolid } from "../components/assets/search-solid
 
 const svgIcons = {
   "ambulance.svg": ambulance,
+  "back-to-top.svg": backToTop,
   "bars-solid.svg": barsSolid,
   "BCID_H_rgb_pos.svg": bcHorizontal,
   "BCID_V_rgb_pos.svg": bcVertical,

--- a/react-app/src/components/Header/Alert/index.js
+++ b/react-app/src/components/Header/Alert/index.js
@@ -120,7 +120,7 @@ function Alert({
       aria-controls={`button-close-alert-${index}`}
       className={alertClasses.join(" ")}
     >
-      {!navHidden && alertHidden ? (
+      {navHidden || (!navHidden && alertHidden) ? (
         <button
           aria-label="Show alert message"
           className="button--show-alert"

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import MediaQuery from "react-responsive";
+import MediaQuery, { useMediaQuery } from "react-responsive";
 import styled from "styled-components";
 
 import Nav from "./Nav";
@@ -20,7 +20,7 @@ const HeaderStyled = styled.header`
   top: 0;
   z-index: 1;
 
-  /* Header width is full page when not scrolled in desktop */
+  /* The left-collapsed header on desktop sizes at least 1271px wide */
   &.header--mini {
     min-height: 125px; // Must be larger than Header + Alert for collapse
     max-width: min-content;
@@ -150,6 +150,7 @@ function Header({ alertMessages, navLinks, satellite, title }) {
   const [searchHidden, setSearchHidden] = useState(true);
   const [slideOutMenuHidden, setSlideOutMenuHidden] = useState(true);
 
+  const isCollapsible = useMediaQuery({ query: `(min-width: 1271px)` });
   const MINIMUM_SCROLL = window.innerHeight / 2;
 
   useDocumentScrollThrottled((callbackData) => {
@@ -196,7 +197,11 @@ function Header({ alertMessages, navLinks, satellite, title }) {
   }
 
   return (
-    <HeaderStyled className={navHidden && slideOutMenuHidden && "header--mini"}>
+    <HeaderStyled
+      className={
+        navHidden && slideOutMenuHidden && isCollapsible && "header--mini"
+      }
+    >
       <div className="wrapper">
         <div className="div--title">
           {/* Satellite sites use vertical logo and decorative pipe with text title in desktop mode */}
@@ -233,12 +238,12 @@ function Header({ alertMessages, navLinks, satellite, title }) {
           )}
         </div>
         <Nav
-          hidden={navHidden && slideOutMenuHidden}
+          hidden={navHidden && slideOutMenuHidden && isCollapsible}
           navLinks={navLinks}
           toggleSearch={toggleSearch}
           toggleSlideOutMenu={toggleSlideOutMenu}
         />
-        {navHidden && slideOutMenuHidden && (
+        {navHidden && slideOutMenuHidden && isCollapsible && (
           <div className="div--header-mini-icons">
             <button
               aria-label="Open the navigation menu"

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -13,6 +13,7 @@ import { ReactComponent as HLogo } from "../assets/BCID_H_rgb_pos.svg";
 import { ReactComponent as VLogo } from "../assets/BCID_V_rgb_pos.svg";
 import { ReactComponent as HamburgerIcon } from "../assets/bars-solid.svg";
 import { ReactComponent as InfoIcon } from "../assets/ionic-ios-information-circle.svg";
+import { ReactComponent as BackToTopIcon } from "../assets/back-to-top.svg";
 
 const HeaderStyled = styled.header`
   background: none;
@@ -142,6 +143,20 @@ const HeaderStyled = styled.header`
   div.wrapper > div.div--header-mini-icons > button#info-icon svg {
     padding: 7px;
   }
+
+  a#a--back-to-top {
+    height: 44px;
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    width: 44px;
+
+    svg {
+      height: 44px;
+      opacity: 0.5;
+      width: 44px;
+    }
+  }
 `;
 
 function Header({ alertMessages, navLinks, satellite, title }) {
@@ -149,6 +164,7 @@ function Header({ alertMessages, navLinks, satellite, title }) {
   const [alertHidden, setAlertHidden] = useState(false);
   const [searchHidden, setSearchHidden] = useState(true);
   const [slideOutMenuHidden, setSlideOutMenuHidden] = useState(true);
+  const [backToTopShown, setBackToTopShown] = useState(false);
 
   const isCollapsible = useMediaQuery({ query: `(min-width: 1271px)` });
   const MINIMUM_SCROLL = window.innerHeight / 2;
@@ -160,6 +176,10 @@ function Header({ alertMessages, navLinks, satellite, title }) {
 
     setNavHidden(() => {
       return isScrolledDown && isMinimumScrolled;
+    });
+
+    setBackToTopShown(() => {
+      return isMinimumScrolled;
     });
   });
 
@@ -288,6 +308,19 @@ function Header({ alertMessages, navLinks, satellite, title }) {
           navLinks={navLinks}
           toggleSlideOutMenu={toggleSlideOutMenu}
         />
+      )}
+      {backToTopShown && slideOutMenuHidden && (
+        <MediaQuery maxWidth={1271}>
+          <a
+            id="a--back-to-top"
+            aria-label="Back to top"
+            onClick={() => {
+              window.scrollTo(0, 0);
+            }}
+          >
+            <BackToTopIcon />
+          </a>
+        </MediaQuery>
       )}
     </HeaderStyled>
   );

--- a/react-app/src/components/assets/back-to-top.svg
+++ b/react-app/src/components/assets/back-to-top.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<path id="Exclusion_1" d="M57,60H3c-1.7,0-3-1.3-3-3V3c0-1.7,1.3-3,3-3h54c1.7,0,3,1.3,3,3v54C60,58.7,58.7,60,57,60z M30,21L30,21
+	L16.2,34.8h7.9v11.9h11.9V34.8h7.9L30,21L30,21z M16.2,13.1v4h27.7v-4H16.2z"/>
+</svg>


### PR DESCRIPTION
- A collapsed Alert button will display any time the Nav menu is hidden - not just when the Alert has been explicitly closed
- The Header collapse logic has been adjusted so that when the NavLinks, Search, UserPanel, and Language buttons are hidden, the Header will no longer collapse (ie. no collapsed Header on mobile)
- A back-to-top link has been added to the Header