### PR TITLE
TabbedContent component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,12 +517,12 @@
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
       }
     },
     "got": {
@@ -612,9 +612,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
     "ipaddr.js": {
@@ -846,9 +846,9 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -21,6 +21,7 @@ import EmploymentStandards from "./pages/Themes/Employment-Business-and-Economic
 import HiringEmployees from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees";
 import HiringDomesticWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers";
 import HiringTemporaryForeignWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers";
+import HiringYoungPeople from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People";
 import ApplyForRecruitersLicense from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License";
 import HowToApply from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/How-to-Apply";
 import OnceYouGetYourLicense from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/Once-You-Get-Your-License";
@@ -87,9 +88,41 @@ function App() {
         ]}
         content={<HiringDomesticWorkers />}
         parentHref={
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/"
         }
         parentTitle={"Employment Standards"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people"
+        }
+        title={"Hiring Young People"}
+        breadcrumbs={[
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment Standards & Workplace Safety",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+            label: "Employment Standards",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees",
+            label: "Hiring Employees",
+          },
+        ]}
+        content={<HiringYoungPeople />}
+        parentHref={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees"
+        }
+        parentTitle={"Hiring Employees"}
       />
       <PrivateRoute
         exact

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -12,6 +12,7 @@ import {
 } from "../components/SteppedGuide";
 import Navigation from "../components/Navigation";
 import OnThisPage from "../components/OnThisPage";
+import TabbedContent from "../components/TabbedContent";
 import Wizard from "../components/Wizard";
 
 function sanitize(input) {
@@ -94,9 +95,9 @@ function buildHtmlElement(
         </Link>
       );
     case "br":
-      return <br key={`${type}-${index}`} />;
+      return <br key={`${type}-${index}-${childIndex ? childIndex : null}`} />;
     case "hr":
-      return <hr />;
+      return <hr key={`${type}-${index}-${childIndex ? childIndex : null}`} />;
     case "h1":
       return (
         <h1
@@ -260,6 +261,13 @@ function buildHtmlElement(
         return <Icon style={{ ...args }} />;
       }
       return null;
+    case "tabbed-content":
+      return (
+        <TabbedContent
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          children={children}
+        />
+      );
     case "wizard":
       return (
         <Wizard

--- a/react-app/src/components/Breadcrumbs.js
+++ b/react-app/src/components/Breadcrumbs.js
@@ -32,17 +32,18 @@ const StyledBreadcrumb = styled.li`
   display: flex;
   float: left;
   height: 48px;
-  margin-left: 20px;
+  /* margin-left: 20px; */
   max-width: 317px;
   overflow: hidden;
 
   svg.svg--breadcrumb-divider {
     overflow: visible;
-    margin-left: 20px;
+    /* margin-left: 20px; */
   }
 
   span.span--breadcrumb-body {
     min-width: 220px;
+    padding: 0 10px;
     width: min-content;
   }
 

--- a/react-app/src/components/Callout.js
+++ b/react-app/src/components/Callout.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import { textService } from "../_services/text.service";

--- a/react-app/src/components/Content.js
+++ b/react-app/src/components/Content.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import { textService } from "../_services/text.service";

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -144,8 +144,11 @@ const HeaderStyled = styled.header`
     padding: 7px;
   }
 
-  a#a--back-to-top {
+  button#button--back-to-top {
+    background: none;
+    border: none;
     height: 44px;
+    padding: 0;
     position: fixed;
     bottom: 10px;
     right: 10px;
@@ -311,15 +314,15 @@ function Header({ alertMessages, navLinks, satellite, title }) {
       )}
       {backToTopShown && slideOutMenuHidden && (
         <MediaQuery maxWidth={1271}>
-          <a
-            id="a--back-to-top"
+          <button
+            id="button--back-to-top"
             aria-label="Back to top"
             onClick={() => {
               window.scrollTo(0, 0);
             }}
           >
             <BackToTopIcon />
-          </a>
+          </button>
         </MediaQuery>
       )}
     </HeaderStyled>

--- a/react-app/src/components/OnThisPage.js
+++ b/react-app/src/components/OnThisPage.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 
 const StyledDiv = styled.div`

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -104,12 +104,12 @@ function Page({
   return (
     <>
       <SkipToMainContentLink />
+      <span id="main-content-anchor"></span>
       <Header title={title} />
       {breadcrumbs && breadcrumbs.length > 0 && (
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       )}
       <main>
-        <a id="main-content-anchor"></a>
         <PageTitle
           title={title}
           parentHref={parentHref}

--- a/react-app/src/components/TabbedContent.js
+++ b/react-app/src/components/TabbedContent.js
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { textService } from "../_services/text.service";
+
+const TabGroup = styled.div`
+  display: flex;
+  flex-flow: row;
+
+  span.span--fill-space {
+    border-bottom: 1px solid #707070;
+    display: inline-block;
+    flex-grow: 1;
+  }
+`;
+
+const Tab = styled.div`
+  display: inline-block;
+  border-left: 1px solid #707070;
+
+  &:nth-last-child(2) {
+    border-right: 1px solid #707070;
+  }
+
+  &.div--tab-active {
+    border-top: 1px solid #707070;
+  }
+
+  button {
+    background: none;
+    border: none;
+    font-size: 18px;
+    font-weight: 700;
+    padding: 10px 20px;
+  }
+`;
+
+const Body = styled.div`
+  border-left: 1px solid #707070;
+  border-right: 1px solid #707070;
+  padding: 20px 18px 6px 18px;
+
+  div.div--tab-body-active {
+    display: block;
+  }
+
+  div.div--tab-body-inactive {
+    display: none;
+  }
+`;
+
+function TabbedContent({ children }) {
+  const [visibleTabIndex, setVisibleTabIndex] = useState(0);
+
+  function handleTabVisibility(tabIndex) {
+    if (visibleTabIndex !== tabIndex) {
+      setVisibleTabIndex(tabIndex);
+    }
+  }
+
+  return (
+    <>
+      <TabGroup>
+        {children?.length > 0 &&
+          children.map(({ label }, index) => {
+            return (
+              <Tab
+                key={`tab-grop-tab-${index}`}
+                className={
+                  index === visibleTabIndex
+                    ? "div--tab-active"
+                    : "div--tab-inactive"
+                }
+              >
+                {label && (
+                  <button onClick={() => handleTabVisibility(index)}>
+                    {label}
+                  </button>
+                )}
+              </Tab>
+            );
+          })}
+        <span className="span--fill-space"></span>
+      </TabGroup>
+      <Body>
+        {/* Since we want the tab info to be on the DOM and able to be index by
+        search engines, render all tab content and hide with CSS as needed. */}
+
+        {children?.length > 0 &&
+          children.map(({ body }, index) => {
+            return (
+              <div
+                key={`tab-group-body-${index}`}
+                className={
+                  index === visibleTabIndex
+                    ? "div--tab-body-active"
+                    : "div--tab-body-inactive"
+                }
+              >
+                {body?.length > 0 &&
+                  body.map((element, index) => {
+                    return textService.buildHtmlElement(element, index);
+                  })}
+              </div>
+            );
+          })}
+      </Body>
+    </>
+  );
+}
+
+export default TabbedContent;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
@@ -1,0 +1,556 @@
+const content = [
+  {
+    type: "wizard",
+    title: "Curate your information",
+    first: "intro",
+    steps: {
+      intro: {
+        text:
+          "Rules are different depending on the situation and the age of the young person being hired. Let us take you through a short questionnaire to show only relevant information for you.",
+        controls: {
+          forward: {
+            label: "Start the questionnaire",
+            step: "start",
+            primary: true,
+          },
+        },
+      },
+      //   start: {
+      //     question_text:
+      //       "Please tell us how you would describe your work situation.",
+      //     options: [
+      //       {
+      //         label: "I am an employee",
+      //         id: "employee",
+      //         next_step: "workplace_safety",
+      //         text:
+      //           "An employee is someone who receives money (or is owed money) for work performed. This includes someone who an employer allows to perform work that would normally be done by an employee.",
+      //       },
+      //       {
+      //         label: "I am an employer",
+      //         id: "employer",
+      //         next_step: "employment_standards",
+      //         text:
+      //           "An employer is someone who hires employees and is responsible for their employment. They have control over employees or provide instruction and/or direction to staff.",
+      //       },
+      //       {
+      //         label: "I am an independent contractor",
+      //         id: "contractor",
+      //         next_step: "workplace_safety",
+      //         text:
+      //           "An independent contractor is considered to be self-employed. Contractors are responsible for upholding workplace standards for their business.",
+      //       },
+      //     ],
+      //     controls: {
+      //       back: {
+      //         label: "Back",
+      //         step: "intro",
+      //       },
+      //       forward: {
+      //         label: "Next",
+      //         primary: true,
+      //       },
+      //     },
+      //   },
+      //   workplace_safety: {
+      //     question_text: "Is your question or concern about workplace safety?",
+      //     options: [
+      //       {
+      //         label: "Yes",
+      //         id: "yes",
+      //         next_step: "worksafe_bc",
+      //       },
+      //       {
+      //         label: "No",
+      //         id: "no",
+      //         next_step: "worksafe_bc",
+      //       },
+      //     ],
+      //     controls: {
+      //       back: {
+      //         label: "Back",
+      //         next_step: "start",
+      //       },
+      //       forward: {
+      //         label: "Next",
+      //         primary: true,
+      //       },
+      //     },
+      //   },
+      //   employment_standards: {
+      //     text:
+      //       "Yes, as an employer, Employment Standards apply. Navigate along to learn more about Employment Standards or seek advice.",
+      //     controls: {
+      //       back: {
+      //         label: "Back",
+      //       },
+      //       restart: {
+      //         label: "Restart",
+      //         primary: true,
+      //       },
+      //     },
+      //   },
+      //   worksafe_bc: {
+      //     text:
+      //       '<p><a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> is the organization primarily responsible for addressing issues concerning workplace health and safety. This includes injuries, illness, or other health and safety incidents.</p>\r\n<p><strong>You can:</strong></p>\r\n<p>- Visit <a href="https://www.worksafebc.com/" class="a--external">WorkSafeBC</a> to learn about workplace health and safety in B.C., to report an incident or to seek resolution</p>\r\n<p>- Contact the <a href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/personal-injury-and-workplace-safety">Workers\u2019 Advisers Office</a> if you disagree with a WorkSafeBC decision</p>',
+      //     controls: {
+      //       back: {
+      //         label: "Back",
+      //       },
+      //       restart: {
+      //         label: "Restart",
+      //         primary: true,
+      //       },
+      //     },
+      //   },
+    },
+  },
+  {
+    type: "hr",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "on-this-page",
+    title: "On This Page",
+    children: [
+      {
+        id: "hiring-under-15-years-old",
+        label: "Hiring Under 15 Years Old",
+      },
+      {
+        id: "contact-the-employment-standards-branch",
+        label: "Contact the Employment Standards Branch",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "hiring-under-15-years-old",
+    children: "Hiring Under 15 Years Old",
+  },
+  {
+    type: "callout",
+    children: [
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            children:
+              "Employers need permission to hire a child under 15 years old",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "A parent or guardian decides if it’s in the best interests of their child to have a job. They must provide written permission for their child to work.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Employers must keep a record of the written consent. It needs to include the child’s date of birth and confirmation that the child’s parent or guardian agrees to the hours, location and type of work the child will be doing.",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "tabbed-content",
+    children: [
+      {
+        label: "Hiring 15 years and older",
+        body: [
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "Employers who hire a young person who is 15 years of age or older must:",
+              },
+            ],
+          },
+          {
+            type: "ul",
+            children: [
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Follow ",
+                      },
+                      {
+                        type: "a-internal",
+                        href: "",
+                        children: "employment standards for regular employees",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Meet ",
+                      },
+                      {
+                        type: "a-internal",
+                        href: "",
+                        children: "WorkSafeBC requirements for young workers",
+                      },
+                      {
+                        type: "text",
+                        children: " (under 25 years old)",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Make any required ",
+                      },
+                      {
+                        type: "a-internal",
+                        href: "",
+                        children: "federal payroll deductions",
+                      },
+                      {
+                        type: "text",
+                        children:
+                          " like income tax and Employment Insurance premiums",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        label: "Rules Hiring ages 12-14",
+        body: [
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Get Parent or Guardian Consent",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "Employers ",
+              },
+              {
+                type: "a-internal",
+                href: "",
+                children:
+                  "need written consent from a parent or guardian (PDF, 20 KB)",
+              },
+              {
+                type: "text",
+                children: ".",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Work Hours",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "Work Hours Children who are 12 to 14 years old cannot:",
+              },
+            ],
+          },
+          {
+            type: "ul",
+            children: [
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Be required to work during school hours",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Work more than four hours on school days",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Work more than seven hours on a non-school day",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Work more than 20 hours during a week with five school days",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Work more than 35 hours a week when school is not in session",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Provide Adult Supervision",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "Employees who are 12 to 14 years old must always be under the direct and immediate supervision of an adult.",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Protect the Child’s Best Interest",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "Parents or guardians need to make sure the child’s employment is in their best interests. They need to:",
+              },
+            ],
+          },
+          {
+            type: "ul",
+            children: [
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Protect the child from work that could be unsafe, interrupt their education or harm their development",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Make sure the child understands what’s expected of them",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children: "Make sure the child can do the job",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "li",
+                children: [
+                  {
+                    type: "p",
+                    children: [
+                      {
+                        type: "text",
+                        children:
+                          "Act as a liaison between their child and other workers",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        label: "Rules Hiring under 12 years old",
+        // body: "Rules Hiring under 12 years old body text",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "contact-the-employment-standards-branch",
+    children: "Contact the Employment Standards Branch",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "Contact us via phone, email, or in person",
+      },
+    ],
+  },
+  {
+    type: "button",
+    children: "Contact the Branch",
+    onClick: null,
+    primary: true,
+  },
+  {
+    type: "br",
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../../../components/Content";
+import { content } from "./data";
+
+function HiringYoungPeople() {
+  return <Content content={content} />;
+}
+
+export default HiringYoungPeople;


### PR DESCRIPTION
This pull request adds the TabbedContent component and uses it on a new page, "Hiring Young People". The TabbedContent component adds all content from each tab to the DOM, but hides everything not on the active tab with with `display: none`. This is sub-optimal from an SEO point of view, but better than not adding the inactive tabbed content to the DOM until the given tab is selected. This will probably need a re-think after it's tested with the search appliance down the road.

Also:
- Breadcrumbs styling is updated to remove wider margins, which are evidently too wide now that we are deeply nested in the IA.
- `#main-content-anchor` is refactored to use a `<span>` tag, to pass a useful linting rule against empty `<a>` tags
- Back-to-top link is refactored to use a button for better accessibility