### PR TITLE
BackToTopButton, ESB content pages

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -18,6 +18,9 @@ import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential
 import EmploymentBusinessAndEconomicDevelopment from "./pages/Themes/Employment-Business-and-Economic-Development";
 import EmploymentStandardsAndWorkplaceSafety from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety";
 import EmploymentStandards from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards";
+import FormsAndResources from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources";
+import GuideToTheEmploymentStandardsAct from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act";
+import EmploymentStandardsAppendices from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices";
 import HiringEmployees from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees";
 import HiringDomesticWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers";
 import HiringTemporaryForeignWorkers from "./pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers";
@@ -323,6 +326,100 @@ function App() {
           },
         ]}
         content={<HiringEmployees />}
+        parentHref={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
+        }
+        parentTitle={"Employment Standards"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act/appendices"
+        }
+        title={"Guide to the Employment Standards Act and Regulations"}
+        breadcrumbs={[
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety",
+            label: "Employment Standards & Workplace Safety",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+            label: "Employment Standards",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources",
+            label: "Forms and Resources",
+          },
+        ]}
+        content={<EmploymentStandardsAppendices />}
+        parentHref={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources"
+        }
+        parentTitle={"Forms and Resources"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act"
+        }
+        title={"Guide to the Employment Standards Act and Regulations"}
+        breadcrumbs={[
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety",
+            label: "Employment Standards & Workplace Safety",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+            label: "Employment Standards",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources",
+            label: "Forms and Resources",
+          },
+        ]}
+        content={<GuideToTheEmploymentStandardsAct />}
+        parentHref={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources"
+        }
+        parentTitle={"Forms and Resources"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources"
+        }
+        title={"Forms and Resources"}
+        breadcrumbs={[
+          {
+            href: "/themes/employment-business-and-economic-development",
+            label: "Employment, Business & Economic Development",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety",
+            label: "Employment Standards & Workplace Safety",
+          },
+          {
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+            label: "Employment Standards",
+          },
+        ]}
+        content={<FormsAndResources />}
         parentHref={
           "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards"
         }

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { imageService } from "./image.service";
 
+import BackToTopButton from "../components/BackToTopButton";
 import { Button, ButtonLink } from "../components/Button";
 import Callout from "../components/Callout";
 import FullWidthBlock from "../components/FullWidthBlock";
@@ -12,6 +13,7 @@ import {
 } from "../components/SteppedGuide";
 import Navigation from "../components/Navigation";
 import OnThisPage from "../components/OnThisPage";
+import SearchBar from "../components/SearchBar";
 import TabbedContent from "../components/TabbedContent";
 import TabbedPageNav from "../components/TabbedPageNav";
 import Wizard from "../components/Wizard";
@@ -35,6 +37,7 @@ function sanitize(input) {
  *   - @param {string} first - ID of the first step in stepped component
  *   - @param {object} steps - JSON representation of steps in stepped component
  *   - @param {object} callToAction - primary action in a stepper component
+ *   - @param {string} placeHolder - placeHolder text for text inputs
  *   - @param {string} href - the `href` of an `a` tag, the `to` of a Link
  *   - @param {Boolean} primary - primary Boolean for Button components
  * @param {number} index - array index for React keys if applicable
@@ -52,6 +55,7 @@ function buildHtmlElement(
     first,
     steps,
     callToAction,
+    placeHolder,
     href,
     primary,
   },
@@ -203,6 +207,12 @@ function buildHtmlElement(
           forwardLabel={args.forwardLabel}
         />
       );
+    case "back-to-top":
+      return (
+        <BackToTopButton
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+        />
+      );
     case "button":
       return (
         <div key={`${type}-${index}-${childIndex ? childIndex : null}`}>
@@ -246,6 +256,13 @@ function buildHtmlElement(
           key={`${type}-${index}-${childIndex ? childIndex : null}`}
           children={children}
           title={title}
+        />
+      );
+    case "search-bar":
+      return (
+        <SearchBar
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          placeHolder={placeHolder || ""}
         />
       );
     case "stepped-guide":

--- a/react-app/src/components/BackToTopButton.js
+++ b/react-app/src/components/BackToTopButton.js
@@ -1,0 +1,49 @@
+import React from "react";
+import propTypes from "prop-types";
+import styled from "styled-components";
+
+const StyledDiv = styled.div`
+  text-align: right;
+  display: block;
+  margin: 20px 0;
+
+  button {
+    background: none;
+    border: none;
+    color: #1a5a96;
+    cursor: pointer;
+    font-size: 18px;
+    margin: 0;
+    padding: 0;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+      color: blue;
+    }
+  }
+`;
+
+function BackToTopButton({ label }) {
+  return (
+    <StyledDiv>
+      <button
+        onClick={() => {
+          window.scrollTo(0, 0);
+        }}
+      >
+        {label}
+      </button>
+    </StyledDiv>
+  );
+}
+
+BackToTopButton.propTypes = {
+  label: propTypes.string,
+};
+
+BackToTopButton.defaultProps = {
+  label: "Back to Top",
+};
+
+export default BackToTopButton;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/data.js
@@ -1,0 +1,136 @@
+const content = [
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "tabbed-page-nav",
+    children: [
+      {
+        label: "Employment Standards",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act",
+      },
+      {
+        label: "Employment Standards Regulations",
+        href: "",
+      },
+      {
+        label: "Definitions",
+        href: "",
+      },
+      {
+        label: "Keyword Index",
+        href: "",
+      },
+      {
+        label: "Appendices",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act/appendices",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "search-bar",
+    placeHolder: "Search the guide",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "- Appendix 1 Repealed (B.C. Reg. 307/2002)",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "- Appendix 2 Repealed (B.C. Reg. 307/2002)",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children:
+          "- Appendix 3 Oil and Gas Well Drilling and Servicing Occupations – Hourly Rate of Pay",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children:
+          "- Appendix 4 Oil and Gas Well Drilling and Servicing Occupations – Salary and Bonus Compensation System",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "hr",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "contact-the-employment-standards-branch",
+    children: "Contact the Employment Standards Branch",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "Contact us via phone, email, or in person",
+      },
+    ],
+  },
+  {
+    type: "button",
+    children: "Contact the Branch",
+    onClick: null,
+    primary: true,
+  },
+  {
+    type: "br",
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../../../../components/Content";
+import { content } from "./data";
+
+function EmploymentStandardsAppendices() {
+  return <Content content={content} />;
+}
+
+export default EmploymentStandardsAppendices;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/data.js
@@ -1,0 +1,290 @@
+const content = [
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "tabbed-page-nav",
+    children: [
+      {
+        label: "Employment Standards",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act",
+      },
+      {
+        label: "Employment Standards Regulations",
+        href: "",
+      },
+      {
+        label: "Definitions",
+        href: "",
+      },
+      {
+        label: "Keyword Index",
+        href: "",
+      },
+      {
+        label: "Appendices",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act/appendices",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "search-bar",
+    placeHolder: "Search the guide",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "on-this-page",
+    title: "Jump to Parts of the Act",
+    children: [
+      {
+        id: "act-part-1",
+        label: "Act Part 1 — Introductory Provisions",
+      },
+      {
+        id: "act-part-2",
+        label: "Act Part 2 — Hiring Employees",
+      },
+      {
+        id: "act-part-3",
+        label: "Act Part 3 — Wages, Special Clothing, Records and Gratuities",
+      },
+      {
+        id: "act-part-4",
+        label: "Act Part 4 — Hours of Work and Overtime",
+      },
+      {
+        id: "act-part-5",
+        label: "Act Part 5 — Statutory Holidays",
+      },
+      {
+        id: "act-part-6",
+        label: "Act Part 6 — Leaves and Jury Duty",
+      },
+      {
+        id: "act-part-7",
+        label: "Act Part 7 — Annual Vacation",
+      },
+      {
+        id: "act-part-8",
+        label: "Act Part 8 — Termination of Employment",
+      },
+      {
+        id: "act-part-9",
+        label: "Act Part 9 — Variances",
+      },
+      {
+        id: "act-part-10",
+        label: "Act Part 10 — Complaints, Investigations and Determinations",
+      },
+      {
+        id: "act-part-11",
+        label: "Act Part 11 — Enforcement",
+      },
+      {
+        id: "act-part-12",
+        label: "Act Part 12 — Employment Standards Tribunal",
+      },
+      {
+        id: "act-part-13",
+        label: "Act Part 13 — Appeals",
+      },
+      {
+        id: "act-part-14",
+        label: "Act Part 14 — General Provisions",
+      },
+    ],
+  },
+  {
+    type: "hr",
+  },
+  {
+    type: "h2",
+    id: "act-part-1",
+    children: "Act Part 1 — Introductory Provisions",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 1 Definitions",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 2 Purposes of this Act",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 3 Scope of this Act",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 4 Requirements of this Act cannot be waived",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 5 Promoting awareness of employment standards",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 6 Informing employees of their rights",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 7 Repealed (B.C. Reg. 431/03)",
+      },
+    ],
+  },
+  {
+    type: "back-to-top",
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "hr",
+  },
+  {
+    type: "h2",
+    id: "act-part-2",
+    children: "Act Part 2 — Hiring Employees",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 8 No False Representations ",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 9 Hiring children",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 10 No charge for hiring or providing information",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 11 No fees to other persons",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 12 Employment and talent agencies must be licensed",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 13 Farm labour contractors must be licensed",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children:
+          "Section 14 Written employment contract required for domestics",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "a-internal",
+        href: "",
+        children: "Section 15 Register of employees working in residences",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../../../components/Content";
+import { content } from "./data";
+
+function GuideToTheEmploymentStandardsAct() {
+  return <Content content={content} />;
+}
+
+export default GuideToTheEmploymentStandardsAct;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
@@ -1,0 +1,35 @@
+const sections = [
+  {
+    title: "Our Services",
+    cards: [
+      {
+        title: "Guide to the Employment Standards Act",
+        cardLink: {
+          href:
+            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act",
+          external: false,
+        },
+      },
+      {
+        title: "Education and Seminars",
+      },
+      {
+        title: "Due Diligence Searches",
+      },
+      {
+        title: "Forms",
+      },
+      {
+        title: "Facts",
+      },
+      {
+        title: "Solutions Explorer",
+      },
+      {
+        title: "Working in B.C. Posters",
+      },
+    ],
+  },
+];
+
+export { sections };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Navigation from "../../../../../../components/Navigation";
+import { sections } from "./data";
+
+function FormsAndResources() {
+  return <Navigation sections={sections} />;
+}
+
+export default FormsAndResources;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
@@ -5,32 +5,22 @@ const content = [
       {
         label: "Overview",
         href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees",
-      },
-      {
-        label: "Hiring Domestic Workers",
-        href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-domestic-workers",
-      },
-      {
-        label: "Hiring Farm Workers",
-        href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-farm-workers",
-      },
-      {
-        label: "Hiring Silviculture Workers",
-        href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-silviculture-workers",
-      },
-      {
-        label: "Requirements to Hiring Temporary Foreign Workers",
-        href:
           "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers",
       },
       {
-        label: "Hiring Young People",
+        label: "Apply for a temporary foreign worker recruiter’s license",
         href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people",
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-a-recruiters-license",
+      },
+      {
+        label: "Search for a registered employer or a licensed recruiter",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/search-for-registered-employer-or-licensed-recruiter",
+      },
+      {
+        label: "Register to Hire Foreign Workers",
+        href:
+          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/register-to-hire-foreign-workers",
       },
     ],
   },
@@ -102,27 +92,4 @@ const content = [
   },
 ];
 
-const navigation = [
-  {
-    label: "Overview",
-    href:
-      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers",
-  },
-  {
-    label: "Apply for a temporary foreign worker recruiter’s license",
-    href:
-      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-a-recruiters-license",
-  },
-  {
-    label: "Search for a registered employer or a licensed recruiter",
-    href:
-      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/search-for-registered-employer-or-licensed-recruiter",
-  },
-  {
-    label: "Register to Hire Foreign Workers",
-    href:
-      "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/register-to-hire-foreign-workers",
-  },
-];
-
-export { content, navigation };
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -8,7 +8,7 @@ const sections = [
           {
             href:
               "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees",
-            label: "Domesic workers",
+            label: "Domestic workers",
           },
           {
             href:
@@ -189,6 +189,11 @@ const sections = [
       {
         title: "Apply for a temporary foreign worker recruiter’s license",
         description: "Follow the steps to apply for a recruiter’s license",
+        cardLink: {
+          href:
+            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-temporary-foreign-workers/apply-for-a-recruiters-license",
+          external: false,
+        },
       },
     ],
   },

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -133,15 +133,18 @@ const sections = [
         title: "Forms & Resources",
         links: [
           {
-            href: "/",
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources",
             label: "Guide to the Employment Standards Act and Regulation",
           },
           {
-            href: "/",
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources",
             label: "Education Seminars",
           },
           {
-            href: "/",
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources",
             label: "Due diligence searches",
           },
         ],


### PR DESCRIPTION
This PR adds the BackToTopButton component, intended for adding a back-to-top link to content pages as desired. This new component and the existing SearchBar component are added to the text service. 

The following new ESB content pages are added:
- Forms and Resources
- Guide to the Employment Standards Act
- Appendices

Additionally:
- Fixes links in TabbedPageNav component on Apply for a Recruiter's License page
- Adds a link to the Recruiter's License card to match design