### PR TITLE
Add SearchBar filtering to Navigation components

### DIFF
--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -3,6 +3,7 @@ import propTypes from "prop-types";
 import MediaQuery from "react-responsive";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import Highlighter from "react-highlight-words";
 
 import { imageService } from "../_services/image.service";
 import { textService } from "../_services/text.service";
@@ -74,6 +75,10 @@ const StyledCard = styled.div`
     height: 1em;
     padding-left: 5px;
   }
+
+  .text--highlighted {
+    background-color: #fcba19;
+  }
 `;
 
 const StyledCardAnchorLink = styled.a`
@@ -126,7 +131,15 @@ function CardAnchorLink({ href, children }) {
 function CardRouterLink({ href, children }) {
   return <StyledCardRouterLink to={href}>{children}</StyledCardRouterLink>;
 }
-function Card({ icon, title, description, links, cardLink, hidden }) {
+function Card({
+  icon,
+  title,
+  description,
+  links,
+  cardLink,
+  hidden,
+  highlightText,
+}) {
   // TODO: Standardize data so only arrays are used
   function getDescMarkup(description) {
     switch (typeof description) {
@@ -151,7 +164,16 @@ function Card({ icon, title, description, links, cardLink, hidden }) {
         <StyledCard className={hidden && "card--hidden"}>
           <div className="card--icon-title">
             {icon && <Icon id={icon} />}
-            {title && <h3>{title}</h3>}
+            {title && (
+              <h3>
+                <Highlighter
+                  highlightClassName="text--highlighted"
+                  searchWords={[highlightText]}
+                  autoEscape={true}
+                  textToHighlight={title}
+                />
+              </h3>
+            )}
             <Icon id="external-link-alt-solid.svg" />
           </div>
           {description && getDescMarkup(description)}
@@ -164,7 +186,16 @@ function Card({ icon, title, description, links, cardLink, hidden }) {
         <StyledCard className={hidden && "card--hidden"}>
           <div className="card--icon-title">
             {icon && <Icon id={icon} />}
-            {title && <h3>{title}</h3>}
+            {title && (
+              <h3>
+                <Highlighter
+                  highlightClassName="text--highlighted"
+                  searchWords={[highlightText]}
+                  autoEscape={true}
+                  textToHighlight={title}
+                />
+              </h3>
+            )}
           </div>
           {description && getDescMarkup(description)}
         </StyledCard>
@@ -175,7 +206,16 @@ function Card({ icon, title, description, links, cardLink, hidden }) {
       <StyledCard className={hidden && "card--hidden"}>
         <div className="card--icon-title">
           {icon && <Icon id={icon} />}
-          {title && <h3>{title}</h3>}
+          {title && (
+            <h3>
+              <Highlighter
+                highlightClassName="text--highlighted"
+                searchWords={[highlightText]}
+                autoEscape={true}
+                textToHighlight={title}
+              />
+            </h3>
+          )}
         </div>
         {description && getDescMarkup(description)}
         {links && links.length > 0 && (
@@ -246,14 +286,21 @@ function Navigation({ search, sections }) {
               <MediaQuery minWidth={576}>
                 <Section key={`section-div-${index}`}>
                   {section?.cards?.length > 0 &&
-                    section.cards.map((card, cardIndex) => {
-                      return (
-                        <Card
-                          key={`section-${index}-card-${cardIndex}`}
-                          {...card}
-                        />
-                      );
-                    })}
+                    section.cards
+                      .filter((card) =>
+                        card.title
+                          ?.toLowerCase()
+                          .includes(filterValue.toLowerCase())
+                      )
+                      .map((card, cardIndex) => {
+                        return (
+                          <Card
+                            key={`section-${index}-card-${cardIndex}`}
+                            highlightText={filterValue.toLowerCase()}
+                            {...card}
+                          />
+                        );
+                      })}
                 </Section>
               </MediaQuery>
 
@@ -266,6 +313,7 @@ function Navigation({ search, sections }) {
                         <Card
                           key={`section-${index}-card-${cardIndex}`}
                           hidden={!mobileAllShown[section.id] && cardIndex >= 3}
+                          highlightText={filterValue.toLowerCase()}
                           {...card}
                         />
                       );

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -212,6 +212,7 @@ function SeeMoreButton({ children, onClick }) {
 
 function Navigation({ search, sections }) {
   const [mobileAllShown, setMobileAllShown] = useState({});
+  const [filterValue, setFilterValue] = useState("");
 
   function handleSeeMore(sectionId) {
     setMobileAllShown((mobileAllShown) => ({
@@ -220,9 +221,18 @@ function Navigation({ search, sections }) {
     }));
   }
 
+  function handleSearchInput(input) {
+    setFilterValue(input);
+  }
+
   return (
     <>
-      {search && <SearchBar placeHolder={search.label || "Search"} />}
+      {search && (
+        <SearchBar
+          parentCallback={handleSearchInput}
+          placeHolder={search.label || "Search"}
+        />
+      )}
       {sections &&
         sections.length > 0 &&
         sections.map((section, index) => {

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
@@ -52,17 +52,23 @@ const SearchButton = styled.button`
   }
 `;
 
-function SearchBar({ placeHolder }) {
-  const searchInput = useRef(null);
+function SearchBar({ parentCallback, placeHolder }) {
+  const [inputValue, setInputValue] = useState("");
 
-  useEffect(() => {
-    searchInput.current.focus();
-  }, []);
+  function onChangeHandler(event) {
+    setInputValue(event.target.value);
+    parentCallback(event.target.value);
+  }
 
   return (
     <SearchForm>
       <form>
-        <input type="search" placeholder={placeHolder} ref={searchInput} />
+        <input
+          type="search"
+          onChange={onChangeHandler}
+          value={inputValue}
+          placeholder={placeHolder}
+        />
         <SearchButton>
           <SearchIcon />
         </SearchButton>

--- a/react-app/src/components/Wizard.js
+++ b/react-app/src/components/Wizard.js
@@ -6,6 +6,7 @@ import { Button } from "./Button";
 
 const StyledWizard = styled.div`
   background-color: #f2f2f2;
+  margin-bottom: 20px;
   padding: 18px 26px;
 
   div.div--wizard-container {

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -1,3 +1,5 @@
+const search = { label: "Search Employment Standards" };
+
 const sections = [
   {
     id: "how-can-we-help-you",
@@ -315,4 +317,4 @@ const content = [
   },
 ];
 
-export { sections, content };
+export { search, sections, content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
@@ -2,13 +2,13 @@ import React from "react";
 
 import Content from "../../../../../components/Content";
 import Navigation from "../../../../../components/Navigation";
-import { sections, content } from "./data";
+import { content, search, sections } from "./data";
 
 function EmploymentStandards() {
   return (
     <>
       <Content content={content} />
-      <Navigation sections={sections} />
+      <Navigation sections={sections} search={search} />
     </>
   );
 }


### PR DESCRIPTION
This PR extends the existing Navigation component's included SearchBar to add filtering by search terms (similar to the Services page).

SearchBar component
- Now accepts a `parentCallback` function to pass its input value to its parent

Navigation component
- The SearchBar is passed a callback which sets the `filterValue` state string that gets used to filter Cards
- `react-highlight-words` is added to highlight the search term entered in the SearchBar component, only for the Card titles initially

The Employment Standards page data is updated with an instance of the SearchBar within the Navigation component.