### PR TITLE
RadioButtonContent component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bc-services-prototype
+# bc-gng-prototype
 
 This package is a prototype re-design of the [Services page](https://www2.gov.bc.ca/gov/content/home/services-a-z) on [gov.bc.ca](https://www2.gov.bc.ca/). It is comprised of a Node/Express back-end and a React front-end.
 
@@ -7,6 +7,8 @@ This package is a prototype re-design of the [Services page](https://www2.gov.bc
 - `./react-app/` holds a React app based on [bc-react-prototype-env](https://github.com/ty2k/bc-react-prototype-env)
 
 ## Installation
+The current version of Node.js required for the project is described in `.nvmrc`.
+
 1. `npm i` to install the Express server dependencies.
 2. Create an environment variable file (`.env`) in the root folder following the example in `.env.example`.
 3. Set a `GUEST_USERNAME` and `GUEST_PASSWORD` environment variable in `.env`:

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -13,6 +13,7 @@ import {
 } from "../components/SteppedGuide";
 import Navigation from "../components/Navigation";
 import OnThisPage from "../components/OnThisPage";
+import RadioButtonGroup from "../components/RadioButtonContent";
 import SearchBar from "../components/SearchBar";
 import TabbedContent from "../components/TabbedContent";
 import TabbedPageNav from "../components/TabbedPageNav";
@@ -263,6 +264,15 @@ function buildHtmlElement(
         <SearchBar
           key={`${type}-${index}-${childIndex ? childIndex : null}`}
           placeHolder={placeHolder || ""}
+        />
+      );
+    case "radio-button-group":
+      return (
+        <RadioButtonGroup
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          children={children}
+          id={id}
+          title={title}
         />
       );
     case "stepped-guide":

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -224,7 +224,7 @@ function buildHtmlElement(
     case "button-link":
       return (
         <div key={`${type}-${index}-${childIndex ? childIndex : null}`}>
-          <ButtonLink key={`${type}-${index}`} primary={primary}>
+          <ButtonLink key={`${type}-${index}`} href={href} primary={primary}>
             {sanitize(children)}
           </ButtonLink>
         </div>

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -4,7 +4,6 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 const StyledButton = styled.button`
-  content: ${(props) => `${props.primary}`};
   background-color: ${(props) => (props.primary ? "#003366" : "white")};
   border-radius: 4px;
   border: 2px solid;
@@ -99,12 +98,11 @@ Button.defaultProps = {
 };
 
 const StyledLink = styled.a`
-  content: ${(props) => `${props.primary}`};
-  background-color: ${(props) => (props.primary ? "#003366" : "white")};
+  background-color: ${(props) => (props.$primary ? "#003366" : "white")};
   border-radius: 4px;
   border: 2px solid;
   border-color: #003366;
-  color: ${(props) => (props.primary ? "white" : "#003366")};
+  color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
@@ -124,12 +122,11 @@ const StyledLink = styled.a`
 `;
 
 const StyledRouterLink = styled(Link)`
-  content: ${(props) => `${props.primary}`};
-  background-color: ${(props) => (props.primary ? "#003366" : "white")};
+  background-color: ${(props) => (props.$primary ? "#003366" : "white")};
   border-radius: 4px;
   border: 2px solid;
   border-color: #003366;
-  color: ${(props) => (props.primary ? "white" : "#003366")};
+  color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
@@ -148,20 +145,35 @@ const StyledRouterLink = styled(Link)`
   }
 `;
 
-function ButtonLink({ children, className, external, href, ...props }) {
+function ButtonLink({
+  children,
+  className,
+  external,
+  href,
+  primary = true,
+  ...props
+}) {
   return (
     <>
       {external ? (
-        <StyledLink href={href} {...props}>
+        <StyledLink href={href} $primary={primary} {...props}>
           {children}
         </StyledLink>
       ) : (
-        <StyledRouterLink to={href} {...props}>
+        <StyledRouterLink to={href} $primary={primary} {...props}>
           {children}
         </StyledRouterLink>
       )}
     </>
   );
 }
+
+ButtonLink.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  external: PropTypes.bool,
+  href: PropTypes.string,
+  primary: PropTypes.bool,
+};
 
 export { Button, ButtonLink };

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -135,8 +135,8 @@ function Card({
     switch (typeof description) {
       case "object":
         if (Array.isArray(description)) {
-          return description.map((element) => {
-            return textService.buildHtmlElement(element);
+          return description.map((element, index) => {
+            return textService.buildHtmlElement(element, index);
           });
         } else {
           return null;
@@ -360,7 +360,7 @@ Navigation.propTypes = {
       cards: propTypes.arrayOf(
         propTypes.shape({
           title: propTypes.string,
-          description: propTypes.string,
+          description: propTypes.any,
           links: propTypes.arrayOf(
             propTypes.shape({
               href: propTypes.string,

--- a/react-app/src/components/RadioButtonContent.js
+++ b/react-app/src/components/RadioButtonContent.js
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { textService } from "../_services/text.service";
+
+const RadioButtonGroup = styled.fieldset`
+  border: none;
+  display: block;
+  margin: 0;
+  padding: 0;
+`;
+
+const RadioButtonOption = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: left;
+  padding-left: 100px;
+
+  @media (max-width: 575px) {
+    display: block;
+    padding-left: 10px;
+  }
+
+  label {
+    display: inline-block;
+    line-height: 44px;
+    padding-left: 20px;
+  }
+`;
+
+const Body = styled.div`
+  div.div--radio-body-active {
+    display: block;
+  }
+
+  div.div--radio-body-inactive {
+    display: none;
+  }
+`;
+
+function RadioButtonContent({ children, id: groupId, title }) {
+  const [visibleRadioIndex, setVisibleRadioIndex] = useState(-1);
+
+  function handleRadioVisibility(radioIndex) {
+    if (visibleRadioIndex !== radioIndex) {
+      setVisibleRadioIndex(radioIndex);
+    }
+  }
+
+  return (
+    <>
+      {title && <h2>{title}</h2>}
+      <RadioButtonGroup id={groupId}>
+        {children?.length > 0 &&
+          children.map(({ id, label }, index) => {
+            return (
+              <RadioButtonOption
+                key={`radio-button-${index}`}
+                className={
+                  index === visibleRadioIndex
+                    ? "div--radio-active"
+                    : "div--radio-inactive"
+                }
+              >
+                <input
+                  type="radio"
+                  id={id}
+                  name={groupId}
+                  onChange={() => handleRadioVisibility(index)}
+                />
+                <label for={id}>{label}</label>
+              </RadioButtonOption>
+            );
+          })}
+      </RadioButtonGroup>
+      <Body>
+        {/* Since we want the radio option's body info to be on the DOM
+        for indexing by search engines, render all tab content and hide
+        with CSS as needed. */}
+
+        {children?.length > 0 &&
+          children.map(({ body }, index) => {
+            return (
+              <div
+                key={`radio-group-body-${index}`}
+                className={
+                  index === visibleRadioIndex
+                    ? "div--radio-body-active"
+                    : "div--radio-body-inactive"
+                }
+              >
+                {body?.length > 0 &&
+                  body.map((element, index) => {
+                    return textService.buildHtmlElement(element, index);
+                  })}
+              </div>
+            );
+          })}
+      </Body>
+    </>
+  );
+}
+
+export default RadioButtonContent;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
@@ -76,33 +76,188 @@ const content = [
     ],
   },
   {
-    type: "wizard",
+    type: "radio-button-group",
+    id: "dispute-resolution",
     title: "I'm a...",
-    first: "intro",
-    steps: {
-      intro: {
-        options: [
+    children: [
+      {
+        id: "tenant",
+        label: "Tenant",
+        body: [
           {
-            label: "Tenant",
-            id: "tenant",
-            next_step: "",
-            content: [],
+            type: "h3",
+            children: "Common Reasons to apply for a dispute resolution",
           },
           {
-            label: "Landlord",
-            id: "landlord",
-            next_step: "",
-            content: [],
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "- Dispute a Notice to End Tenancy",
+              },
+            ],
           },
           {
-            label: "Respondent",
-            id: "respondent",
-            next_step: "",
-            content: [],
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "- Have a landlord make repairs to the rental unit or property",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "- Apply for compensation from a landlord for money owed or other tenancy-related issues",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h3",
+            children: "Direct Requests",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "When a tenancy ends and the landlord receives the tenant’s forwarding address in writing, the landlord has fifteen days to either return the outstanding deposit(s) or make an application to retain part or all of the deposit(s).",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "If the landlord does nothing, tenants have an alternative option to get a Monetary Order. This is called a Direct Request.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "- ",
+              },
+              {
+                type: "a-internal",
+                children: "Learn How to Apply for a Tenant’s Direct Request",
+                href: "/",
+              },
+            ],
           },
         ],
       },
-    },
+      {
+        id: "landlord",
+        label: "Landlord",
+        body: [
+          {
+            type: "h3",
+            children: "Common Reasons to apply for a dispute resolution",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "- Apply for an Order of Possession because a tenant hasn’t moved out when they should",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "- Claim money from a tenant for unpaid rent or damages",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h3",
+            children: "Direct Requests",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "When a tenant receives a 10 Day Notice to End Tenancy for Unpaid Rent or Utilities, they have five days to either pay the overdue amount or dispute it. If the tenant does nothing, landlords have an alternative option to get an Order of Possession. This is called a Landlord Direct Request.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "A landlord can use a Direct Request to claim for an order of possession when a tenant hasn’t paid their rent or utilities and a monetary order for unpaid rent or utilities or payment of the filing fee.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "- ",
+              },
+              {
+                type: "a-internal",
+                children: "Learn How to Apply for a Landlord’s Direct Request",
+                href: "/",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "respondent",
+        label: "Respondent",
+        body: [
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "As a respondent, you’d have received a Notice of Dispute Resolution Hearing Package with a Dispute Access Code. With that you can add your evidence online though the Dispute Access Site.",
+              },
+            ],
+          },
+          {
+            type: "button-link",
+            children: "Dispute Access Site",
+            external: "false",
+            href: "/",
+            primary: true,
+          },
+          {
+            type: "br",
+          },
+        ],
+      },
+    ],
   },
   {
     type: "back-forward-button-pair",
@@ -182,7 +337,7 @@ const content = [
         type: "button-link",
         children: "Contact the Branch",
         external: "false",
-        href: "",
+        href: "/",
         primary: true,
       },
     ],


### PR DESCRIPTION
This PR adds the RadioButtonContent component, built off of the existing TabbedContent component. I went with a new component instead of complicating the existing one because the styling and logic are both slightly different. The TabbedContent always displays the body content of the first Tab in the list, whereas the RadioButtonContent component starts with no choices pre-selected and no body content shown.

An instance of the RadioButtonContent is used on the RTB "Online Dispute Resolution Applications" overview page.

Also included:
- Updates `README.md` with a correct title and instructions to use the version of Node specified in `.nvmrc`
- In the Button component, a `styled-components` transient prop (`$primary`) is used for the styling of primary Buttons
- A console warning due to duplicate keys in the Navigation component is fixed by passing an element index to the text service within the Card sub-component