### PR TITLE
RTB During a Tenancy content pages

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -17,6 +17,7 @@ import Contact from "./pages/Contact";
 import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
 import DuringATenancy from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy";
+import RentIncreases from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases";
 import DisputeResolutionApplications from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications";
 import OnlineDisputeResolutionApplication from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application";
 import ODRABeforeYouApply from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply";
@@ -272,6 +273,30 @@ function App() {
         content={<DisputeResolutionApplications />}
         parentHref={"/themes/housing-and-tenancy/residential-tenancies"}
         parentTitle={"Residential Tenancies"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases"
+        }
+        title={"Rent Increases"}
+        breadcrumbs={[
+          { href: "/themes/housing-and-tenancy", label: "Housing & Tenancy" },
+          {
+            href: "/themes/housing-and-tenancy/residential-tenancies",
+            label: "Residential Tenancies",
+          },
+          {
+            href:
+              "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy",
+            label: "During a Tenancy",
+          },
+        ]}
+        content={<RentIncreases />}
+        parentHref={
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy"
+        }
+        parentTitle={"During a Tenancy"}
       />
       <PrivateRoute
         exact

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -18,6 +18,7 @@ import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
 import DuringATenancy from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy";
 import RentIncreases from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases";
+import StandardRentIncreases from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases";
 import DisputeResolutionApplications from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications";
 import OnlineDisputeResolutionApplication from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application";
 import ODRABeforeYouApply from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply";
@@ -273,6 +274,30 @@ function App() {
         content={<DisputeResolutionApplications />}
         parentHref={"/themes/housing-and-tenancy/residential-tenancies"}
         parentTitle={"Residential Tenancies"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/standard-rent-increases"
+        }
+        title={"Rent Increases"}
+        breadcrumbs={[
+          { href: "/themes/housing-and-tenancy", label: "Housing & Tenancy" },
+          {
+            href: "/themes/housing-and-tenancy/residential-tenancies",
+            label: "Residential Tenancies",
+          },
+          {
+            href:
+              "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy",
+            label: "During a Tenancy",
+          },
+        ]}
+        content={<StandardRentIncreases />}
+        parentHref={
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy"
+        }
+        parentTitle={"During a Tenancy"}
       />
       <PrivateRoute
         exact

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -16,6 +16,7 @@ import Contact from "./pages/Contact";
 // Residential Tenancy Branch pages
 import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
+import DuringATenancy from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy";
 import DisputeResolutionApplications from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications";
 import OnlineDisputeResolutionApplication from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application";
 import ODRABeforeYouApply from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply";
@@ -269,6 +270,23 @@ function App() {
           },
         ]}
         content={<DisputeResolutionApplications />}
+        parentHref={"/themes/housing-and-tenancy/residential-tenancies"}
+        parentTitle={"Residential Tenancies"}
+      />
+      <PrivateRoute
+        exact
+        path={
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy"
+        }
+        title={"During a Tenancy"}
+        breadcrumbs={[
+          { href: "/themes/housing-and-tenancy", label: "Housing & Tenancy" },
+          {
+            href: "/themes/housing-and-tenancy/residential-tenancies",
+            label: "Residential Tenancies",
+          },
+        ]}
+        content={<DuringATenancy />}
         parentHref={"/themes/housing-and-tenancy/residential-tenancies"}
         parentTitle={"Residential Tenancies"}
       />

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -251,7 +251,10 @@ function buildHtmlElement(
       );
     case "callout":
       return (
-        <Callout key={`${type}-${index}-${childIndex ? childIndex : null}`}>
+        <Callout
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          className={className}
+        >
           {children}
         </Callout>
       );

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -108,6 +108,7 @@ const StyledLink = styled.a`
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
+  margin: 18px 0;
   min-height: 44px;
   padding: 10px 30px;
   text-align: center;
@@ -132,6 +133,7 @@ const StyledRouterLink = styled(Link)`
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
+  margin: 18px 0;
   min-height: 44px;
   padding: 10px 30px;
   text-align: center;

--- a/react-app/src/components/Callout.js
+++ b/react-app/src/components/Callout.js
@@ -4,14 +4,45 @@ import styled from "styled-components";
 import { textService } from "../_services/text.service";
 
 const StyledDiv = styled.div`
-  border-left: 6px solid #fcba19;
+  border-left: 6px solid;
   margin: 20px 0;
   padding: 0 0 0 18px;
+
+  &.error {
+    border-color: #fc1919;
+  }
+  &.info {
+    border-color: #003366;
+  }
+  &.success {
+    border-color: #2d4821;
+  }
+  &.warning {
+    border-color: #fcba19;
+  }
 `;
 
-function Callout({ children }) {
+function Callout({ children, className }) {
+  let style = "";
+
+  switch (className) {
+    case "error":
+      style = "error";
+      break;
+    case "info":
+      style = "info";
+      break;
+    case "success":
+      style = "success";
+      break;
+    case "warning":
+    default:
+      style = "warning";
+      break;
+  }
+
   return (
-    <StyledDiv>
+    <StyledDiv className={style}>
       {children.map((child, index) => {
         return textService.buildHtmlElement(child, index);
       })}

--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -83,13 +83,13 @@ const StyledCard = styled.div`
 
 const StyledCardAnchorLink = styled.a`
   color: inherit;
-  display: flex;
+  display: inherit;
   text-decoration: inherit;
 `;
 
 const StyledCardRouterLink = styled(Link)`
   color: inherit;
-  display: flex;
+  display: inherit;
   text-decoration: inherit;
 `;
 

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/data.js
@@ -332,7 +332,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/data.js
@@ -453,7 +453,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
@@ -248,7 +248,7 @@ const content = [
           {
             type: "button-link",
             children: "Dispute Access Site",
-            external: "false",
+            external: false,
             href: "/",
             primary: true,
           },
@@ -336,7 +336,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/data.js
@@ -443,7 +443,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/data.js
@@ -159,7 +159,7 @@ const content = [
   {
     type: "button-link",
     children: "Try the Online Calculators",
-    external: "false",
+    external: false,
     href: "/",
     primary: true,
   },
@@ -209,7 +209,7 @@ const content = [
   {
     type: "button-link",
     children: "Register for a Basic BCeID",
-    external: "true",
+    external: true,
     href: "https://www.bceid.ca/register/",
     primary: true,
   },
@@ -426,7 +426,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/data.js
@@ -108,7 +108,7 @@ const content = [
   {
     type: "button-link",
     children: "Apply Online",
-    external: "false",
+    external: false,
     href: "/",
     primary: true,
   },
@@ -257,7 +257,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/data.js
@@ -425,7 +425,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/data.js
@@ -186,7 +186,7 @@ const content = [
       {
         type: "button-link",
         children: "Contact the Branch",
-        external: "false",
+        external: false,
         href: "/",
         primary: true,
       },

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/data.js
@@ -1,0 +1,268 @@
+const content = [
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "tabbed-page-nav",
+    children: [
+      {
+        label: "Rent Increases Overview",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
+      },
+      {
+        label: "Standard Rent Increases",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/standard-rent-increases",
+      },
+      {
+        label: "Proportional Amount Rent Increase",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/proportional-amount-rent-increase",
+      },
+      {
+        label: "Additional Rent Increase",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/additional-rent-increase",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "on-this-page",
+    title: "On this Page",
+    children: [
+      {
+        id: "overview",
+        label: "Overview",
+      },
+      {
+        id: "rent-increase-calculator",
+        label: "Rent Increase Calculator",
+      },
+      {
+        id: "notifying-tenants",
+        label: "Notifying Tenants",
+      },
+      {
+        id: "related-links",
+        label: "Related Links",
+      },
+      {
+        id: "contact-the-rtb",
+        label: "Contact the Residential Tenancy Branch",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "overview",
+    children: "Overview",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Landlords must provide tenants with three full rental months’ notice of a rent increase.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Manufactured home park landlords who do not wish to increase rent by the allowable proportional amount may apply a standard rent increase.",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "callout",
+    className: "error",
+    children: [
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            style: "strong",
+            children:
+              "NOTE: A landlord can give a notice of rent increase however, the increase will not come into effect until December 1, 2020. Go to the COVID-19 page for more details.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "rent-increase-calculator",
+    children: "Rent Increase Calculator",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "What are the rules about rent increases in B.C.? How much can landlords increase rent by in B.C.? Use the rent increase calculator and get information about rent increases for landlords and tenants.",
+      },
+    ],
+  },
+  {
+    type: "button-link",
+    children: "Rent Increase Calculator",
+    external: false,
+    href: "/",
+    primary: true,
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "notifying-tenants",
+    children: "Notifying Tenants",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Landlords must give tenants a copy of one of the completed forms depending on the type of tenancy:",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "- Notice of Rent Increase - Residential Rental Units (PDF, 1.7MB)",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "- Notice of Standard Rent Increase – Manufactured Home Site (PDF)",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Be sure to complete both pages of the form – including all of the boxes on the second page. Please note that the amount of the calculated increase must not be rounded up.",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "back-forward-button-pair",
+    args: {
+      backHref:
+        "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
+      backLabel: "Rent Increases Overview",
+      forwardHref:
+        "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/proportional-amount-rent-increase",
+      forwardLabel: "Proportional Amount Rent Increase",
+    },
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "related-links",
+    children: "Related Links",
+  },
+  {
+    type: "navigation",
+    children: [
+      {
+        cards: [
+          {
+            title: "Paying Rent",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+          {
+            title: "Changes to the Agreement",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+          {
+            title: "Repairs and Maintenance",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "full-width-block",
+    children: [
+      {
+        type: "h2",
+        children: "Contact the Residential Tenancy Branch",
+        id: "contact-the-rtb",
+      },
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            children: "Contact us via phone, email, or in person",
+          },
+        ],
+      },
+      {
+        type: "button-link",
+        children: "Contact the Branch",
+        external: false,
+        href: "/",
+        primary: true,
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../../../components/Content";
+import { content } from "./data";
+
+function StandardRentIncreases() {
+  return <Content content={content} />;
+}
+
+export default StandardRentIncreases;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/data.js
@@ -1,0 +1,344 @@
+const content = [
+  {
+    type: "p",
+    className: "p--last-updated",
+    children: [
+      {
+        type: "text",
+        style: "normal",
+        children: "Last Updated: December 12, 2020",
+      },
+    ],
+  },
+  {
+    type: "tabbed-page-nav",
+    children: [
+      {
+        label: "Rent Increases Overview",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
+      },
+      {
+        label: "Standard Rent Increases",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/standard-rent-increases",
+      },
+      {
+        label: "Proportional Amount Rent Increase",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/proportional-amount-rent-increase",
+      },
+      {
+        label: "Additional Rent Increase",
+        href:
+          "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/additional-rent-increase",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "on-this-page",
+    title: "On this Page",
+    children: [
+      {
+        id: "overview",
+        label: "Overview",
+      },
+      {
+        id: "rent-increase-calculator",
+        label: "Rent Increase Calculator",
+      },
+      {
+        id: "maximum-allowable-rent-increase",
+        label: "Maximum Allowable Rent Increase",
+      },
+      {
+        id: "related-links",
+        label: "Related Links",
+      },
+      {
+        id: "contact-the-rtb",
+        label: "Contact the Residential Tenancy Branch",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "overview",
+    children: "Overview",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "When a tenancy ends and the landlord receives the tenant’s forwarding address in writing, the landlord has fifteen days to either return the outstanding deposit(s) or make an application to retain part or all of the deposit(s).",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "- See more details by clicking here.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "A rent increase for a tenant with a fixed-term agreement (lease), who is remaining in a rental unit, is limited to the maximum annual allowable amount and can only be increased once every 12 months. Rent can no longer be increased above that amount between tenancy agreements with the same tenant.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Landlords are no longer able to apply for an additional rent increase on the basis that the rent is significantly lower than other similar rental units in the same geographic area.",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "rent-increase-calculator",
+    children: "Rent Increase Calculator",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "What are the rules about rent increases in B.C.? How much can landlords increase rent by in B.C.? Use the rent increase calculator and get information about rent increases for landlords and tenants.",
+      },
+    ],
+  },
+  {
+    type: "button-link",
+    children: "Rent Increase Calculator",
+    external: false,
+    href: "/",
+    primary: true,
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "maximum-allowable-rent-increase",
+    children: "Maximum Allowable Rent Increase",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "The landlord may only increase the rent 12 months after the date that the existing rent was established with the existing tenant(s) or 12 months after the date of the last legal rent increase, even if there is a new landlord or a new tenant by way of an assignment.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "The maximum allowable rent increase is defined as the 12-month average percent change in the all-items Consumer Price Index for British Columbia ending in the July that is most recently available for the calendar year for which a rent increase takes effect.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "For example, if a rent increase takes effect in 2021, the maximum allowable rent increase is the 12-month average percent change in the all-items Consumer Price Index for British Columbia ending in July 2020.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "BC Stats publishes the 12-month average percent change in the all-items Consumer Price Index for British Columbia:",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "- Twelve-month averages and percent change (XLSX)",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "The limits for residential tenancies and manufactured home park tenancies are different.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "- For residential tenancies, the standard allowable rent increase for 2021 is 1.4%",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children: "- For residential tenancies use the form RTB-7",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "- For manufactured home park tenancies, the standard allowable rent increase for 2021 is 1.4% plus a proportional amount for the change in local government levies and regulated utility fees​",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "- For manufactured home park tenancy rent increases taking place in 2021 use the form RTB-11a​",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Subsidized housing, where rent is related to the tenant’s income, is not subject to rent increase laws. In these cases, the Residential Tenancy Branch does not have the authority to make decisions on rent increases. Tenants who have questions about rent increases for subsidized housing should discuss it with the housing provider.​",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "The rent increase cannot be more than the amount calculated using the allowable increase percentage. This means a landlord can’t round up when calculating the allowable increase. For example, if the base rent is $1,100 and the maximum allowable increase is $15.40 the landlord can issue a Notice of Rent Increase for a new rent of up to $1,115.40, but not $1,116.00",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "back-forward-button-pair",
+    args: {
+      backHref: "",
+      backLabel: "",
+      forwardHref:
+        "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases/standard-rent-increases",
+      forwardLabel: "Standard Rent Increases",
+    },
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h2",
+    id: "related-links",
+    children: "Related Links",
+  },
+  {
+    type: "navigation",
+    children: [
+      {
+        cards: [
+          {
+            title: "Paying Rent",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+          {
+            title: "Changes to the Agreement",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+          {
+            title: "Repairs and Maintenance",
+            description:
+              "Find out what needs to happen in situations where tenants must be notified. For example, when a landlord wants to enter a rental unit, end a tenancy, discontinue services or schedule a showing.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "full-width-block",
+    children: [
+      {
+        type: "h2",
+        children: "Contact the Residential Tenancy Branch",
+        id: "contact-the-rtb",
+      },
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            children: "Contact us via phone, email, or in person",
+          },
+        ],
+      },
+      {
+        type: "button-link",
+        children: "Contact the Branch",
+        external: false,
+        href: "/",
+        primary: true,
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../../components/Content";
+import { content } from "./data";
+
+function RentIncreases() {
+  return <Content content={content} />;
+}
+
+export default RentIncreases;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
@@ -1,0 +1,58 @@
+const sections = [
+  {
+    title: "",
+    cards: [
+      {
+        title: "Paying Rent",
+      },
+      {
+        title: "Rent Increases",
+        cardLink: {
+          href:
+            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
+          external: false,
+        },
+      },
+      {
+        title: "Repairs & Maintenance",
+      },
+      {
+        title: "Landlord's Access",
+      },
+      {
+        title: "Possession of the Unit",
+        cardLink: {
+          href:
+            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/possession-of-the-unit",
+          external: false,
+        },
+      },
+      {
+        title: "Quiet Enjoyment",
+      },
+      {
+        title: "Changes to the Agreement",
+      },
+      {
+        title: "Pets",
+      },
+      {
+        title: "Sublet & Assignment",
+      },
+      {
+        title: "Selling a Tenanted Property",
+      },
+      {
+        title: "Serving Notices During Tenancy",
+      },
+      {
+        title: "Get it in Writing",
+      },
+      {
+        title: "Cannabis",
+      },
+    ],
+  },
+];
+
+export { sections };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
@@ -4,12 +4,7 @@ import Navigation from "../../../../../components/Navigation";
 import { sections } from "./data";
 
 function DuringATenancy() {
-  return (
-    <Navigation
-      // search={{ label: "Search Residential Tenancies" }}
-      sections={sections}
-    />
-  );
+  return <Navigation sections={sections} />;
 }
 
 export default DuringATenancy;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+import Navigation from "../../../../../components/Navigation";
+import { sections } from "./data";
+
+function DuringATenancy() {
+  return (
+    <Navigation
+      // search={{ label: "Search Residential Tenancies" }}
+      sections={sections}
+    />
+  );
+}
+
+export default DuringATenancy;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
@@ -50,7 +50,12 @@ const sections = [
       {
         title: "During a Tenancy",
         description:
-          "Learn your rights and responsibilities during a tenancy, including information on rent increases, repairs, and",
+          "Learn your rights and responsibilities during a tenancy, including information on rent increases, repairs and maintenance.",
+        cardLink: {
+          href:
+            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy",
+          external: false,
+        },
       },
       {
         title: "Ending a Tenancy",


### PR DESCRIPTION
This PR adds the RTB "During a Tenancy" content page and its sub pages "Rent Increases Overview" and "Standard Rent Increases".

Additional updates:
- Styling of Cards within the Navigation component is fixed so that Card-level links display properly (`display: block` caused Cards with only titles to display at a reduced width)
- Instances of the ButtonLink component have their data fixed to use Booleans properly instead of JavaScript string coercion
- ButtonLink component has vertical margin added to it for better flow on page
- Callout component now accepts a `className` parameter for displaying different colors, similar to the current [Alert Banners](https://developer.gov.bc.ca/Design-System/Alert-Banners) within the Design System