### PR TITLE
RTB Forms page and initial Table component

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -16,6 +16,7 @@ import Contact from "./pages/Contact";
 // Residential Tenancy Branch pages
 import HousingAndTenancy from "./pages/Themes/Housing-and-Tenancy";
 import ResidentialTenancies from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies";
+import Forms from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms";
 import DuringATenancy from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy";
 import RentIncreases from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases";
 import StandardRentIncreases from "./pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases";
@@ -363,6 +364,21 @@ function App() {
         ]}
         content={<DuringATenancy />}
         parentHref={"/themes/housing-and-tenancy/residential-tenancies"}
+        parentTitle={"Residential Tenancies"}
+      />
+      <PrivateRoute
+        exact
+        path={"/themes/housing-and-tenancy/residential-tenancies/forms"}
+        title={"Forms"}
+        breadcrumbs={[
+          { href: "/themes/housing-and-tenancy", label: "Housing & Tenancy" },
+          {
+            href: "/themes/housing-and-tenancy/residential-tenancies",
+            label: "Residential Tenancies",
+          },
+        ]}
+        content={<Forms />}
+        parentHref={"/themes/housing-and-tenancy/residential-tenancies/"}
         parentTitle={"Residential Tenancies"}
       />
       <PrivateRoute

--- a/react-app/src/_services/image.service.js
+++ b/react-app/src/_services/image.service.js
@@ -44,6 +44,8 @@ import { ReactComponent as nounMedicalCross } from "../components/assets/noun-pr
 import { ReactComponent as passportSolid } from "../components/assets/passport-solid.svg";
 import { ReactComponent as planeSolid } from "../components/assets/plane-solid.svg";
 import { ReactComponent as searchSolid } from "../components/assets/search-solid.svg";
+import { ReactComponent as sortDownSolid } from "../components/assets/sort-down-solid.svg";
+import { ReactComponent as sortUpSolid } from "../components/assets/sort-up-solid.svg";
 
 const svgIcons = {
   "ambulance.svg": ambulance,
@@ -92,6 +94,8 @@ const svgIcons = {
   "passport-solid.svg": passportSolid,
   "plane-solid.svg": planeSolid,
   "search-solid.svg": searchSolid,
+  "sort-down-solid.svg": sortDownSolid,
+  "sort-up-solid.svg": sortUpSolid,
 };
 
 function getSvg(id) {

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -181,7 +181,7 @@ function buildHtmlElement(
       );
     case "p":
       return (
-        <p key={`${type}-${index}`} className={className}>
+        <p key={`${type}-${index}-${childIndex}`} className={className}>
           {children.map((child, childIndex) => {
             return buildHtmlElement(child, index, childIndex);
           })}

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 import { imageService } from "./image.service";
 
-import Accordion from "../components/Accordion";
+import { Accordion, MoreInfo } from "../components/Accordion";
 import BackToTopButton from "../components/BackToTopButton";
 import { Button, ButtonLink } from "../components/Button";
 import Callout from "../components/Callout";
@@ -267,6 +267,12 @@ function buildHtmlElement(
         >
           {children}
         </FullWidthBlock>
+      );
+    case "more-info":
+      return (
+        <MoreInfo key={`${type}-${index}-${childIndex ? childIndex : null}`}>
+          {children}
+        </MoreInfo>
       );
     case "navigation":
       return (

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -18,6 +18,7 @@ import RadioButtonGroup from "../components/RadioButtonContent";
 import SearchBar from "../components/SearchBar";
 import TabbedContent from "../components/TabbedContent";
 import TabbedPageNav from "../components/TabbedPageNav";
+import Table from "../components/Table";
 import Wizard from "../components/Wizard";
 
 function sanitize(input) {
@@ -34,6 +35,7 @@ function sanitize(input) {
  *   - @param {*} children - a string for primitive elements,
  *                           or an array or for composed elements
  *                           like `p`, `span`, or React components
+ *   - @param {object} data - JSON object data for React components
  *   - @param {object} args - arbitrary arguments for React components
  *   - @param {string} title - title for React components
  *   - @param {string} first - ID of the first step in stepped component
@@ -54,6 +56,7 @@ function buildHtmlElement(
     style,
     className,
     children,
+    data,
     args,
     title,
     first,
@@ -332,6 +335,14 @@ function buildHtmlElement(
         <TabbedPageNav
           key={`${type}-${index}-${childIndex ? childIndex : null}`}
           children={children}
+        />
+      );
+    case "table":
+      return (
+        <Table
+          key={`${type}-${index}${childIndex ? `-${childIndex}` : ""}`}
+          data={data}
+          id={id}
         />
       );
     case "wizard":

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -53,6 +53,7 @@ const AccordionBody = styled.div`
   }
 `;
 
+// Full page-width accordion component which can be linked to on-page
 function Accordion({ expanded = false, id, title, children }) {
   const hashFragment = window.location.href.split("#")[1];
   const directlyLinked = Boolean(hashFragment && id && hashFragment === id);
@@ -87,4 +88,83 @@ function Accordion({ expanded = false, id, title, children }) {
   );
 }
 
-export default Accordion;
+const StyledMoreInfo = styled.div`
+  display: block;
+  margin: 0 0 13px 0;
+`;
+
+const MoreInfoHeader = styled.div`
+  display: block;
+  margin: 10px 0;
+
+  button.button--more-info {
+    background: none;
+    border: 0;
+    display: block;
+    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
+    font-size: 18px;
+    font-weight: 400;
+    min-height: 44px;
+    margin: 0 0 8px 0;
+    padding: 0;
+
+    span {
+      color: #1a5a96;
+      text-decoration: underline;
+    }
+
+    svg {
+      color: #1a5a96;
+      margin-left: 7px;
+      width: 14px;
+    }
+  }
+`;
+
+const MoreInfoBody = styled.div`
+  p {
+    margin: 0 0;
+  }
+
+  &.closed {
+    display: none;
+  }
+
+  &.open {
+    display: block;
+    margin: 0 0 23px 0;
+  }
+`;
+
+// Minimal accordion-style component for use within Table cells
+function MoreInfo({ id, children }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <StyledMoreInfo id={id}>
+      <MoreInfoHeader>
+        <button
+          className={"button--more-info"}
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          <span>More info</span>
+          {open ? (
+            <Icon id={"sort-up-solid.svg"} />
+          ) : (
+            <Icon id={"sort-down-solid.svg"} />
+          )}
+        </button>
+      </MoreInfoHeader>
+      <MoreInfoBody className={open ? "open" : "closed"}>
+        {children &&
+          children.map((element) => {
+            return textService.buildHtmlElement(element);
+          })}
+      </MoreInfoBody>
+    </StyledMoreInfo>
+  );
+}
+
+export { Accordion, MoreInfo };

--- a/react-app/src/components/Table.js
+++ b/react-app/src/components/Table.js
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { textService } from "../_services/text.service";
+import Icon from "./Icon";
+
+const StyledTable = styled.table`
+  border-collapse: collapse;
+  table-layout: auto;
+  width: 100%;
+
+  tr {
+    border-bottom: 1px solid #707070;
+
+    td {
+      padding: 0 8px;
+      vertical-align: top;
+    }
+
+    th {
+      padding: 0 8px;
+
+      button {
+        background: none;
+        border: 0;
+        font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
+        font-size: 20px;
+        font-weight: 700;
+        min-height: 44px;
+        margin: 0 0 8px 0;
+        padding: 0;
+
+        &.sorted {
+          color: #1a5a96;
+          text-decoration: underline;
+          text-decoration-thickness: 1px;
+          text-underline-offset: 2px;
+        }
+
+        svg {
+          margin-left: 7px;
+          width: 14px;
+        }
+      }
+    }
+  }
+`;
+
+function Table({ data, id }) {
+  const [sortConfig, setSortConfig] = useState(data.sortConfig || {});
+
+  // Sort ascending to start, switch to descending, and so on
+  function handleSort(id) {
+    let direction = "ascending";
+
+    if (sortConfig.id === id && sortConfig.direction === "ascending") {
+      direction = "descending";
+    }
+
+    setSortConfig({ id: id, direction: direction });
+  }
+
+  // Table heading button displays an up or down arrow when sorted
+  function getSortIcon() {
+    switch (sortConfig.direction) {
+      case "ascending":
+        return <Icon id={"sort-down-solid.svg"} />;
+      case "descending":
+        return <Icon id={"sort-up-solid.svg"} />;
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <StyledTable id={id}>
+      {/* Column headings are buttons that can be used to sort the table */}
+      <thead>
+        <tr>
+          {data?.thead?.cols?.length > 0 &&
+            data.thead.cols.map((col, index) => {
+              return (
+                <th
+                  key={`table-${data.id}-thead-col-${col.id}`}
+                  style={{
+                    textAlign: `${col.align}`,
+                    width: `${col.width}%`,
+                  }}
+                >
+                  <button
+                    className={sortConfig.id === col.id ? "sorted" : null}
+                    type="button"
+                    onClick={() => handleSort(col.id)}
+                  >
+                    {col.label}
+                    {sortConfig.id === col.id && getSortIcon()}
+                  </button>
+                </th>
+              );
+            })}
+        </tr>
+      </thead>
+
+      {/* Table body is an array of rows that can be sorted by heading */}
+      <tbody>
+        {data?.tbody?.length > 0 &&
+          data.tbody.map((row, rowIndex) => {
+            return (
+              <tr key={`table-${data.id}-tbody-row-${rowIndex}`}>
+                {row?.cols?.length > 0 &&
+                  row.cols.map((col, colIndex) => {
+                    return (
+                      <td
+                        key={`table-${data.id}-tbody-row-${rowIndex}-col-${colIndex}`}
+                        style={{
+                          textAlign: `${col.align}`,
+                        }}
+                      >
+                        {col?.children?.length > 0 &&
+                          col.children.map((elem, elemIndex) => {
+                            return textService.buildHtmlElement(
+                              elem,
+                              rowIndex,
+                              elemIndex
+                            );
+                          })}
+                      </td>
+                    );
+                  })}
+              </tr>
+            );
+          })}
+      </tbody>
+    </StyledTable>
+  );
+}
+
+export default Table;

--- a/react-app/src/components/assets/sort-down-solid.svg
+++ b/react-app/src/components/assets/sort-down-solid.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-down" class="svg-inline--fa fa-sort-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z"></path></svg>

--- a/react-app/src/components/assets/sort-up-solid.svg
+++ b/react-app/src/components/assets/sort-up-solid.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-up" class="svg-inline--fa fa-sort-up fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279 224H41c-21.4 0-32.1-25.9-17-41L143 64c9.4-9.4 24.6-9.4 33.9 0l119 119c15.2 15.1 4.5 41-16.9 41z"></path></svg>

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
@@ -1,0 +1,339 @@
+const content = [
+  {
+    type: "table",
+    id: "forms-table",
+    data: {
+      sortConfig: {
+        id: "form-number",
+        direction: "ascending",
+      },
+      thead: {
+        cols: [
+          {
+            id: "form",
+            align: "left",
+            label: "Form",
+            width: "80",
+          },
+          {
+            id: "form-number",
+            align: "center",
+            label: "Form Number",
+            width: "20",
+          },
+        ],
+      },
+      tbody: [
+        {
+          cols: [
+            {
+              align: "left",
+              children: [
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children:
+                        "Residential Tenancy Agreement for Internet Explorer",
+                    },
+                  ],
+                },
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "text",
+                      children: "(Last Updated: Oct-18) (PDF, 271 KB)",
+                    },
+                  ],
+                },
+                {
+                  type: "more-info",
+                  id: "more-info-form-rtb-1",
+                  label: "More",
+                  children: [
+                    {
+                      type: "p",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "A Tenancy Agreement is a contract between a landlord and a tenant that outlines the terms of the tenancy - it's an important legal document. This Tenancy Agreement template accurately reflects the Residential Tenancy Act and is best viewed using Internet Explorer.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              align: "center",
+              children: [
+                {
+                  type: "p",
+                  style: "strong",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "RTB-1",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          cols: [
+            {
+              align: "left",
+              children: [
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children:
+                        "Residential Tenancy Agreement for other browsers",
+                    },
+                  ],
+                },
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "text",
+                      children: "(Last Updated: Oct-18) (PDF, 239 KB)",
+                    },
+                  ],
+                },
+                {
+                  type: "more-info",
+                  id: "more-info-form-rtb-1",
+                  label: "More",
+                  children: [
+                    {
+                      type: "p",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "A Tenancy Agreement is a contract between a landlord and a tenant that outlines the terms of the tenancy - it's an important legal document. This Tenancy Agreement template accurately reflects the Residential Tenancy Act and is best viewed using most browsers.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              align: "center",
+              children: [
+                {
+                  type: "p",
+                  style: "strong",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "RTB-1C",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          cols: [
+            {
+              align: "left",
+              children: [
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "Application for Review Consideration",
+                    },
+                  ],
+                },
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "text",
+                      children: "(Last Updated: Jan-21) (PDF, 645 KB)",
+                    },
+                  ],
+                },
+                {
+                  type: "more-info",
+                  id: "more-info-form-rtb-1",
+                  label: "More",
+                  children: [
+                    {
+                      type: "p",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "Use this form to apply for review of an arbitrator's order or decision.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              align: "center",
+              children: [
+                {
+                  type: "p",
+                  style: "strong",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "RTB-2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          cols: [
+            {
+              align: "left",
+              children: [
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "Manufactured Home Site Tenancy Agreement",
+                    },
+                  ],
+                },
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "text",
+                      children: "(Last Updated: Dec-17) (PDF, 163 KB)",
+                    },
+                  ],
+                },
+                {
+                  type: "more-info",
+                  id: "more-info-form-rtb-1",
+                  label: "More",
+                  children: [
+                    {
+                      type: "p",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "A Manufactured Home Site Tenancy Agreement is a contract between a park owner and the manufactured home owner that outlines the terms of the tenancy for the site – it’s an important legal document. This Tenancy Agreement templates accurately reflect the Manufactured Home Park Tenancy Act and can be viewed in most browsers.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              align: "center",
+              children: [
+                {
+                  type: "p",
+                  style: "strong",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "RTB-5",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          cols: [
+            {
+              align: "left",
+              children: [
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "Request for Correction",
+                    },
+                  ],
+                },
+                {
+                  type: "p",
+                  children: [
+                    {
+                      type: "text",
+                      children: "(Last Updated: Jan-21) (PDF, 710 KB)",
+                    },
+                  ],
+                },
+                {
+                  type: "more-info",
+                  id: "more-info-form-rtb-1",
+                  label: "More",
+                  children: [
+                    {
+                      type: "p",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "Use this form to request that an arbitrator correct any obvious error or inadvertent omission.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              align: "center",
+              children: [
+                {
+                  type: "p",
+                  style: "strong",
+                  children: [
+                    {
+                      type: "a-internal",
+                      href: "/",
+                      children: "RTB-6",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+import Content from "../../../../../components/Content";
+import { content } from "./data";
+
+function ResidentialTenancies() {
+  return <Content content={content} />;
+}
+
+export default ResidentialTenancies;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
@@ -16,6 +16,10 @@ const sections = [
         title: "Forms",
         description:
           "The forms page has new forms to make applying for dispute resolution easier.",
+        cardLink: {
+          href: "/themes/housing-and-tenancy/residential-tenancies/forms",
+          external: false,
+        },
       },
       {
         title: "Resources and Calculators",


### PR DESCRIPTION
This PR adds the RTB Forms page with an instance of the Table component.

Table component notes
- Currently only set up to use the first row as the `<th>` heading, not the left column
- The styling for sorting is in place but items are not yet sortable
- No filtering is in place within the Table itself (this should probably exist one level up as a radio content item)

Additionally:
- A more minimally styled accordion component called MoreInfo is added for use within the Table
- The FontAwesome `sort-down-solid` and `sort-up-solid` icons are included for use in the new Table and MoreInfo components
- To ensure unique React keys, the paragraph element in the text service now takes a `childIndex` parameter