### PR TITLE
Support multiple sets of credentials

### DIFF
--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -23,6 +23,7 @@ const StyledTable = styled.table`
       button {
         background: none;
         border: 0;
+        color: #313132;
         font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
         font-size: 20px;
         font-weight: 700;
@@ -73,7 +74,7 @@ function TableGroup({ context = {}, data, id }) {
   }
 
   // Sort ascending to start, switch to descending, and so on
-  function handleSort(id) {
+  function handleSortButton(id) {
     let direction = "ascending";
 
     if (sortConfig.id === id && sortConfig.direction === "ascending") {
@@ -154,7 +155,8 @@ function TableGroup({ context = {}, data, id }) {
                     <button
                       className={sortConfig.id === col.id ? "sorted" : null}
                       type="button"
-                      onClick={() => handleSort(col.id)}
+                      disabled
+                      onClick={() => handleSortButton(col.id)}
                     >
                       {col.label}
                       {sortConfig.id === col.id && getSortIcon()}

--- a/react-app/src/pages/Login/index.js
+++ b/react-app/src/pages/Login/index.js
@@ -56,7 +56,7 @@ function Login(props) {
             setUserName(e.target.value);
           }}
           placeholder="Username"
-          autoComplete="username"
+          autoComplete="off"
         />
         <TextInput
           label="Password"
@@ -67,7 +67,7 @@ function Login(props) {
             setPassword(e.target.value);
           }}
           placeholder="Password"
-          autoComplete="current-password"
+          autoComplete="off"
         />
         <Button type="submit" disabled={isSubmitting} primary={true}>
           Login

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
@@ -95,7 +95,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Residential Tenancy Agreement for Internet Explorer",
                         children: [
                           {
                             type: "p",
@@ -139,7 +142,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-1",
                         children: [
                           {
                             type: "p",
@@ -164,7 +169,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Residential Tenancy Agreement for other browsers",
                         children: [
                           {
                             type: "p",
@@ -208,7 +216,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-1C",
                         children: [
                           {
                             type: "p",
@@ -233,7 +243,9 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort: "Application for Review Consideration",
                         children: [
                           {
                             type: "p",
@@ -277,7 +289,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-2",
                         children: [
                           {
                             type: "p",
@@ -302,7 +316,9 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort: "Manufactured Home Site Tenancy Agreement",
                         children: [
                           {
                             type: "p",
@@ -346,7 +362,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-5",
                         children: [
                           {
                             type: "p",
@@ -371,7 +389,9 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort: "Request for Correction",
                         children: [
                           {
                             type: "p",
@@ -414,7 +434,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-6",
                         children: [
                           {
                             type: "p",
@@ -439,7 +461,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Notice of Rent Increase - Residential Rental Units",
                         children: [
                           {
                             type: "p",
@@ -497,7 +522,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-7",
                         children: [
                           {
                             type: "p",
@@ -522,7 +549,9 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort: "Mutual Agreement to End a Tenancy",
                         children: [
                           {
                             type: "p",
@@ -565,7 +594,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-8",
                         children: [
                           {
                             type: "p",
@@ -590,7 +621,9 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort: "Proof of Service Notice of Expedited Hearing",
                         children: [
                           {
                             type: "p",
@@ -633,7 +666,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-9",
                         children: [
                           {
                             type: "p",
@@ -658,7 +693,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Request for Consent to Assign a Manufactured Home Site Tenancy Agreement",
                         children: [
                           {
                             type: "p",
@@ -701,7 +739,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-10",
                         children: [
                           {
                             type: "p",
@@ -726,7 +766,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Notice of Rent Increase - Manufactured Home Site - (auto-calculating version)",
                         children: [
                           {
                             type: "p",
@@ -825,7 +868,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-11A",
                         children: [
                           {
                             type: "p",
@@ -850,7 +895,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Landlord Application for Dispute Resolution - Current Tenancy",
                         children: [
                           {
                             type: "p",
@@ -894,7 +942,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-12L-CT",
                         children: [
                           {
                             type: "p",
@@ -919,7 +969,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Landlord Application for Dispute Resolution - Past Tenancy",
                         children: [
                           {
                             type: "p",
@@ -963,7 +1016,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-12L-PT",
                         children: [
                           {
                             type: "p",
@@ -988,7 +1043,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Tenant Application for Dispute Resolution - Current Tenancy",
                         children: [
                           {
                             type: "p",
@@ -1032,7 +1090,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-12T-CT",
                         children: [
                           {
                             type: "p",
@@ -1057,7 +1117,10 @@ const content = [
                     },
                     cols: [
                       {
+                        colId: "form",
                         align: "left",
+                        sort:
+                          "Tenant Application for Dispute Resolution - Past Tenancy",
                         children: [
                           {
                             type: "p",
@@ -1101,7 +1164,9 @@ const content = [
                         ],
                       },
                       {
+                        colId: "form-number",
                         align: "center",
+                        sort: "RTB-12T-PT",
                         children: [
                           {
                             type: "p",

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
@@ -4,14 +4,18 @@ const sections = [
     cards: [
       {
         title: "Residential Tenancies",
+        cardLink: {
+          href: "/themes/housing-and-tenancy/residential-tenancies",
+          external: false,
+        },
         description: "Info and services for tenants and landlords.",
         links: [
           {
-            href: "/themes/housing-and-tenancy/residential-tenancies",
+            href: "/under-construction",
             label: "Tips for landlords & renters",
           },
           {
-            href: "/themes/housing-and-tenancy/residential-tenancies",
+            href: "/themes/housing-and-tenancy/residential-tenancies/forms",
             label: "Tenancy Agreements",
           },
         ],

--- a/server.js
+++ b/server.js
@@ -5,8 +5,15 @@ const path = require('path');
 const bodyParser = require('body-parser');
 const servicesData = require('./services.json');
 const PORT = process.env.PORT || 8080;
-const GUEST_USERNAME = process.env.GUEST_USERNAME;
-const GUEST_PASSWORD = process.env.GUEST_PASSWORD;
+const USER_PASS_PAIRS = process.env.USER_PASS_PAIRS;
+
+// Split USER_PASS_PAIRS env var into valid credentials
+const credsArr = USER_PASS_PAIRS.split(',');
+const credsObj = {};
+credsArr.forEach((userPassStr) => {
+  const userPassArr = userPassStr.split('|');
+  credsObj[userPassArr[0]] = userPassArr[1];
+})
 
 // Use React's build directory as static mount point
 app.use(express.static(path.join(__dirname, 'react-app', 'build')));
@@ -21,8 +28,8 @@ app.get('/api/services', function(req, res) {
 
 app.post('/api/login', function(req, res) {
   if (req.body &&
-      req.body.username === GUEST_USERNAME &&
-      req.body.password === GUEST_PASSWORD) {
+      req.body.username in credsObj &&
+      req.body.password === credsObj[req.body.username]) {
     console.log("Authenticated");
     res.json({ "username": req.body.username });
   } else {


### PR DESCRIPTION
This PR updates the Express backend to use a string of credential pairs from an environment variable (`USER_PASS_PAIRS`) rather than just a single user/pass combination, to be able to support limited-time credentials for research participants.

The Heroku deployment will likewise be updated with the new environment variable to support this.

Also:
- TableGroup component filter buttons are disabled until they are functional
- RTB Forms table data is extended with `colId` and `sort` parameters for future filtering
- The Login page input fields are set to `autocomplete="off'`
- RTB Housing and Tenancy page is updated with `cardLink` data for valid Cards