### PR TITLE
Mobile margin

### DIFF
--- a/react-app/src/App.scss
+++ b/react-app/src/App.scss
@@ -32,7 +32,7 @@ main {
 
 @media (min-width: 576px) {
   main {
-    max-width: 576px;
+    max-width: 556px;
   }
 }
 

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -28,7 +28,7 @@ const AccordionHeader = styled.div`
       display: inline-block;
       font-size: 20px;
       font-weight: 700;
-      margin: 0 12px;
+      margin: 12px;
       text-align: left;
     }
 
@@ -52,6 +52,10 @@ const AccordionBody = styled.div`
   &.open {
     display: block;
     margin: 26px 52px;
+
+    @media (max-width: 575px) {
+      margin: 10px;
+    }
   }
 `;
 

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -19,6 +19,11 @@ const StyledButton = styled.button`
   text-align: center;
   text-decoration: none;
 
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   &:active {
     opacity: 1;
   }
@@ -114,6 +119,11 @@ const StyledLink = styled.a`
   text-align: center;
   text-decoration: none;
 
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   &:hover {
     background-color: #003366;
     color: white;
@@ -138,6 +148,11 @@ const StyledRouterLink = styled(Link)`
   padding: 10px 30px;
   text-align: center;
   text-decoration: none;
+
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
 
   &:hover {
     background-color: #003366;

--- a/react-app/src/components/Callout.js
+++ b/react-app/src/components/Callout.js
@@ -20,6 +20,11 @@ const StyledDiv = styled.div`
   &.warning {
     border-color: #fcba19;
   }
+
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
 `;
 
 function Callout({ children, className }) {

--- a/react-app/src/components/Content.js
+++ b/react-app/src/components/Content.js
@@ -18,6 +18,26 @@ const StyledContent = styled.div`
     color: #888888;
     font-size: 16px;
     margin: 4px 0 20px 0;
+
+    @media (max-width: 575px) {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
+  }
+
+  @media (max-width: 575px) {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    ul,
+    ol {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
   }
 `;
 

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -159,6 +159,11 @@ const HeaderStyled = styled.header`
       opacity: 0.5;
       width: 44px;
     }
+
+    @media (max-width: 575px) {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
   }
 `;
 

--- a/react-app/src/components/OnThisPage.js
+++ b/react-app/src/components/OnThisPage.js
@@ -2,6 +2,11 @@ import React from "react";
 import styled from "styled-components";
 
 const StyledDiv = styled.div`
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   h2 {
     font-size: 20px;
     font-weight: 400;

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -75,6 +75,11 @@ const StyledPageTitle = styled.div`
   display: block;
   margin: 20px 0;
 
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   a {
     display: inline;
     margin-right: 5px;

--- a/react-app/src/components/RadioButtonContent.js
+++ b/react-app/src/components/RadioButtonContent.js
@@ -8,6 +8,11 @@ const RadioButtonGroup = styled.fieldset`
   display: block;
   margin: 0;
   padding: 0;
+
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
 `;
 
 const RadioButtonOption = styled.div`

--- a/react-app/src/components/RadioButtonContent.js
+++ b/react-app/src/components/RadioButtonContent.js
@@ -15,16 +15,20 @@ const RadioButtonOption = styled.div`
   display: flex;
   justify-content: left;
   padding-left: 100px;
+  margin: 10px;
 
   @media (max-width: 575px) {
     display: block;
     padding-left: 10px;
   }
 
+  input {
+    float: left;
+  }
+
   label {
-    display: inline-block;
-    line-height: 44px;
-    padding-left: 20px;
+    display: block;
+    padding-left: 25px;
   }
 `;
 

--- a/react-app/src/components/SteppedGuide.js
+++ b/react-app/src/components/SteppedGuide.js
@@ -2,13 +2,18 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 
-import { Button, ButtonLink } from "./Button";
+import { ButtonLink } from "./Button";
 import { ReactComponent as LeftArrowIcon } from "../components/assets/ionic-ios-arrow-back.svg";
 import { ReactComponent as RightArrowIcon } from "../components/assets/ionic-ios-arrow-forward.svg";
 
 const StyledGuide = styled.div`
   border-bottom: 1px solid #707070;
   padding-bottom: 29px;
+
+  @media (max-width: 575px) {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
 `;
 
 const StyledGrid = styled.div`
@@ -112,14 +117,28 @@ const StyledLinkButtonPair = styled.div`
   display: flex;
   justify-content: space-between;
 
+  @media (max-width: 575px) {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+
   a {
     align-items: center;
     display: flex;
     padding: 10px 20px;
 
+    @media (max-width: 575px) {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
+
     &:last-child {
       margin-left: auto;
       margin-right: 0;
+
+      @media (max-width: 575px) {
+        margin-right: 10px;
+      }
     }
 
     svg {


### PR DESCRIPTION
This PR adds margin to the following components for proper display on mobile and tablet displays:
- Accordion
- Button/ButtonLink
- Callout
- OnThisPage
- SteppedGuide
- RadioButtonContent
- Content component
- Page component
- Header component's back-to-top button

The `max-width` on the 576px breakpoint is reduced to 556px for proper margin.