### PR TITLE
CheckboxContent component

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ The current version of Node.js required for the project is described in `.nvmrc`
 
 1. `npm i` to install the Express server dependencies.
 2. Create an environment variable file (`.env`) in the root folder following the example in `.env.example`.
-3. Set a `GUEST_USERNAME` and `GUEST_PASSWORD` environment variable in `.env`:
+3. To give yourself credentials to develop with, add a `USER_PASS_PAIRS` environment variable in `.env`:
 ```
-GUEST_USERNAME=user
-GUEST_PASSWORD=pass
+USER_PASS_PAIRS=username|password,seconduser|secondpassword
 ```
 
 ## Build

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -8,6 +8,7 @@ import BackButton from "../components/BackButton";
 import BackToTopButton from "../components/BackToTopButton";
 import { Button, ButtonLink } from "../components/Button";
 import Callout from "../components/Callout";
+import CheckboxContent from "../components/CheckboxContent";
 import FullWidthBlock from "../components/FullWidthBlock";
 import {
   SteppedGuide,
@@ -277,6 +278,16 @@ function buildHtmlElement(
         >
           {children}
         </Callout>
+      );
+    case "checkbox-content":
+      return (
+        <CheckboxContent
+          key={`${type}-${index}${childIndex ? `-${childIndex}` : ""}`}
+          children={children}
+          defaultContent={defaultContent}
+          id={id}
+          title={title}
+        />
       );
     case "full-width-block":
       return (

--- a/react-app/src/components/CheckboxContent.js
+++ b/react-app/src/components/CheckboxContent.js
@@ -1,0 +1,164 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { textService } from "../_services/text.service";
+
+const CheckboxGroup = styled.fieldset`
+  background-color: #f2f2f2;
+  border: none;
+  color: #313132;
+  display: block;
+  margin: 0;
+  padding: 6px 25px;
+
+  h2 {
+    margin-top: 0;
+  }
+
+  @media (max-width: 575px) {
+    padding: 6px 10px;
+  }
+`;
+
+const CheckboxOptionsGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin: 20px 10px 50px 10px;
+`;
+
+const CheckboxOption = styled.div`
+  align-items: center;
+  background-color: white;
+  border: 1px solid #d1d1d1;
+  display: inline;
+  justify-content: left;
+
+  input[type="checkbox"] {
+    display: none;
+  }
+
+  label {
+    cursor: pointer;
+    display: block;
+    font-size: 20px;
+    font-weight: 700;
+    min-width: 350px;
+    padding: 20px;
+    width: 100%;
+
+    &:hover {
+      color: blue;
+      text-decoration: underline;
+    }
+
+    @media (max-width: 575px) {
+      min-width: 0;
+    }
+  }
+
+  input[type="checkbox"]:checked + label {
+    color: #1a5a96;
+    text-decoration: underline;
+  }
+`;
+
+const Body = styled.div`
+  div.div--checkbox-body-active {
+    display: block;
+  }
+
+  div.div--checkbox-body-inactive {
+    display: none;
+  }
+`;
+
+function CheckboxContent({ children, defaultContent, id: groupId, title }) {
+  const [checkedBox, setCheckedBox] = useState("");
+
+  function handleCheckbox(id) {
+    if (checkedBox === id) {
+      // uncheck the box
+      setCheckedBox("");
+    } else {
+      // check the box
+      setCheckedBox(id);
+    }
+  }
+
+  return (
+    <>
+      <CheckboxGroup>
+        {title && <h2 id={groupId}>{title}</h2>}
+        <CheckboxOptionsGroup>
+          {children?.length > 0 &&
+            children.map(({ id, label }, index) => {
+              return (
+                <CheckboxOption
+                  key={`checkbox-group-${groupId}-box-number-${index}`}
+                  className={
+                    id === checkedBox
+                      ? "div--checkbox-checked"
+                      : "div--checkbox-unchecked"
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={id === checkedBox}
+                    id={id}
+                    name={groupId}
+                    onChange={() => handleCheckbox(id)}
+                  />
+                  <label htmlFor={id}>{label}</label>
+                </CheckboxOption>
+              );
+            })}
+        </CheckboxOptionsGroup>
+      </CheckboxGroup>
+      <Body>
+        {/* Display the defaultContent when no checkboxes are selected */}
+
+        {defaultContent && (
+          <div
+            className={
+              !checkedBox
+                ? "div--checkbox-body-active"
+                : "div--checkbox-body-inactive"
+            }
+          >
+            {defaultContent?.length > 0 &&
+              defaultContent?.map((element, index) => {
+                return textService.buildHtmlElement(element, index);
+              })}
+          </div>
+        )}
+
+        {/* Since we want the checkbox option's body info to be on the DOM
+        for indexing by search engines, render all tab content and hide
+        with CSS as needed. */}
+
+        {children?.length > 0 &&
+          children.map(({ body, id }, index) => {
+            return (
+              <div
+                key={`checkbox-group-body-${index}`}
+                className={
+                  id === checkedBox
+                    ? "div--checkbox-body-active"
+                    : "div--checkbox-body-inactive"
+                }
+              >
+                {body?.length > 0 &&
+                  body.map((element, index) => {
+                    return textService.buildHtmlElement(element, index);
+                  })}
+              </div>
+            );
+          })}
+      </Body>
+    </>
+  );
+}
+
+export default CheckboxContent;

--- a/react-app/src/components/OnThisPage.js
+++ b/react-app/src/components/OnThisPage.js
@@ -5,21 +5,36 @@ const StyledDiv = styled.div`
   @media (max-width: 575px) {
     margin-left: 10px;
     margin-right: 10px;
+
+    h2.h2--on-this-page {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    ol.ol--on-this-page {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    li.li--on-this-page {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
 
-  h2 {
+  h2.h2--on-this-page {
     font-size: 20px;
     font-weight: 400;
     margin: 12px 0;
   }
 
-  ol {
+  ol.ol--on-this-page {
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
-  li {
+  li.li--on-this-page {
     margin: 12px 0;
   }
 `;
@@ -27,11 +42,14 @@ const StyledDiv = styled.div`
 function OnThisPage({ title, children }) {
   return (
     <StyledDiv>
-      <h2>{title}</h2>
-      <ol>
+      <h2 className={"h2--on-this-page"}>{title}</h2>
+      <ol className={"ol--on-this-page"}>
         {children.map((child, index) => {
           return (
-            <li key={`on-this-page-list-item-${index}`}>
+            <li
+              key={`on-this-page-list-item-${index}`}
+              className={"li--on-this-page"}
+            >
               <a href={`#${child.id}`}>{child.label}</a>
             </li>
           );

--- a/react-app/src/components/TabbedContent.js
+++ b/react-app/src/components/TabbedContent.js
@@ -28,6 +28,7 @@ const TabGroup = styled.div`
 const Tab = styled.div`
   display: inline-block;
   border-left: 1px solid #707070;
+  border-top: 1px solid transparent;
 
   &:nth-last-child(2) {
     border-right: 1px solid #707070;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/data.js
@@ -14,80 +14,75 @@ const content = [
     type: "br",
   },
   {
+    type: "h2",
+    id: "overview",
+    children: "Overview",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "Possession in residential tenancies refers to the right of a landlord or a tenant to use and enjoy the property.",
+      },
+    ],
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "A tenancy agreement protects the rights and responsibilities of landlords and tenants – if either party doesn’t respect the rights of the other, they may lose some of their rights. ",
+      },
+      {
+        type: "a-internal",
+        href: "/under-construction",
+        children: "Dispute resolution",
+      },
+      {
+        type: "text",
+        children:
+          " may be required if either party doesn’t meet their responsibilities or negatively affects the rights of the other.",
+      },
+    ],
+  },
+  {
     type: "br",
   },
   {
-    type: "radio-button-group",
+    type: "checkbox-content",
     id: "dispute-resolution",
     title: "I'm a...",
     defaultContent: [
       {
-        type: "p",
+        type: "on-this-page",
+        title: "On this Page",
         children: [
           {
-            type: "on-this-page",
-            title: "On this Page",
-            children: [
-              {
-                id: "default-overview",
-                label: "Overview",
-              },
-              {
-                id: "default-your-rights",
-                label: "Your Rights",
-              },
-              {
-                id: "default-locks",
-                label: "Locks",
-              },
-              {
-                id: "default-enforcing-possession",
-                label: "Enforcing Possession",
-              },
-              {
-                id: "related-links",
-                label: "Related Links",
-              },
-              {
-                id: "contact-the-rtb",
-                label: "Contact the Residential Tenancy Branch",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: "h2",
-        id: "default-overview",
-        children: "Overview",
-      },
-      {
-        type: "p",
-        children: [
-          {
-            type: "text",
-            children:
-              "Possession in residential tenancies refers to the right of a landlord or a tenant to use and enjoy the property.",
-          },
-        ],
-      },
-      {
-        type: "p",
-        children: [
-          {
-            type: "text",
-            children:
-              "A tenancy agreement protects the rights and responsibilities of landlords and tenants – if either party doesn’t respect the rights of the other, they may lose some of their rights. ",
+            id: "overview",
+            label: "Overview",
           },
           {
-            type: "a-internal",
-            href: "/under-construction",
-            children: "Dispute resolution",
+            id: "default-your-rights",
+            label: "Your Rights",
           },
           {
-            type: "text",
-            children:
-              " may be required if either party doesn’t meet their responsibilities or negatively affects the rights of the other.",
+            id: "default-locks",
+            label: "Locks",
+          },
+          {
+            id: "default-enforcing-possession",
+            label: "Enforcing Possession",
+          },
+          {
+            id: "related-links",
+            label: "Related Links",
+          },
+          {
+            id: "contact-the-rtb",
+            label: "Contact the Residential Tenancy Branch",
           },
         ],
       },
@@ -328,33 +323,32 @@ const content = [
         label: "Tenant",
         body: [
           {
-            type: "p",
+            type: "on-this-page",
+            title: "On this Page",
             children: [
               {
-                type: "on-this-page",
-                title: "On this Page",
-                children: [
-                  {
-                    id: "tenant-rights",
-                    label: "Tenant Rights",
-                  },
-                  {
-                    id: "tenant-locks",
-                    label: "Locks",
-                  },
-                  {
-                    id: "tenant-enforcing-possession",
-                    label: "Enforcing Possession",
-                  },
-                  {
-                    id: "related-links",
-                    label: "Related Links",
-                  },
-                  {
-                    id: "contact-the-rtb",
-                    label: "Contact the Residential Tenancy Branch",
-                  },
-                ],
+                id: "overview",
+                label: "Overview",
+              },
+              {
+                id: "tenant-rights",
+                label: "Tenant Rights",
+              },
+              {
+                id: "tenant-locks",
+                label: "Locks",
+              },
+              {
+                id: "tenant-enforcing-possession",
+                label: "Enforcing Possession",
+              },
+              {
+                id: "related-links",
+                label: "Related Links",
+              },
+              {
+                id: "contact-the-rtb",
+                label: "Contact the Residential Tenancy Branch",
               },
             ],
           },
@@ -518,33 +512,32 @@ const content = [
         label: "Landlord",
         body: [
           {
-            type: "p",
+            type: "on-this-page",
+            title: "On this Page",
             children: [
               {
-                type: "on-this-page",
-                title: "On this Page",
-                children: [
-                  {
-                    id: "landlord-rights",
-                    label: "Landlord Rights",
-                  },
-                  {
-                    id: "landlord-locks",
-                    label: "Locks",
-                  },
-                  {
-                    id: "landlord-enforcing-possession",
-                    label: "Enforcing Possession",
-                  },
-                  {
-                    id: "related-links",
-                    label: "Related Links",
-                  },
-                  {
-                    id: "contact-the-rtb",
-                    label: "Contact the Residential Tenancy Branch",
-                  },
-                ],
+                id: "overview",
+                label: "Overview",
+              },
+              {
+                id: "landlord-rights",
+                label: "Landlord Rights",
+              },
+              {
+                id: "landlord-locks",
+                label: "Locks",
+              },
+              {
+                id: "landlord-enforcing-possession",
+                label: "Enforcing Possession",
+              },
+              {
+                id: "related-links",
+                label: "Related Links",
+              },
+              {
+                id: "contact-the-rtb",
+                label: "Contact the Residential Tenancy Branch",
               },
             ],
           },


### PR DESCRIPTION
This PR adds the CheckboxContent component and uses it on the RTB During a Tenancy "Possession of the Unit" page. This control differs slightly from the existing RadioButtonContent component in that it is possible using the new CheckboxContent to move back to the "default" content state with no option selected. Though it uses true checkbox inputs, it is similar to a radio group in that it has handling to only allow one checkbox to be selected at once.

Additional updates:
- OnThisPage table of contents components has proper margins added to mobile screen sizes
- TabbedContent tabs are giving `border-top: 1px solid transparent` so that when the `1px solid black` top border is added in the active state, layout jumping no longer occurs
- `README.md` is updated with instructions to add a `USER_PASS_PAIRS` environment variable for local development