### PR TITLE
Under construction tooltip

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -19496,6 +19496,22 @@
         "use-latest": "^1.0.0"
       }
     },
+    "react-tooltip": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.13.tgz",
+      "integrity": "sha512-iAZ02wSxChLWb7Vnu0zeQMyAo/jiGHrwFNILWaR3pCKaFVRjKcv/B6TBI4+Xd66xLXVzLngwJ91Tf5D+mqAqVA==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
     "reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -15,6 +15,7 @@
     "react-responsive": "^8.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
+    "react-tooltip": "^4.2.13",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/react-app/src/components/Header/Nav/SearchBar.js
+++ b/react-app/src/components/Header/Nav/SearchBar.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
+import ReactTooltip from "react-tooltip";
 import styled from "styled-components";
 
+import constructionMessage from "../../../pages/Under-Construction/message";
 import SearchButton from "./SearchButton";
 
 const SearchForm = styled.div`
@@ -49,8 +51,14 @@ function SearchBar({ placeHolder }) {
   return (
     <SearchForm>
       <form>
-        <input type="search" placeholder={placeHolder} ref={searchInput} />
-        <SearchButton />
+        <ReactTooltip />
+        <input
+          type="search"
+          placeholder={placeHolder}
+          ref={searchInput}
+          data-tip={constructionMessage}
+        />
+        <SearchButton data-tip={constructionMessage} />
       </form>
     </SearchForm>
   );

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import { NavLink } from "react-router-dom";
+import ReactTooltip from "react-tooltip";
 import styled from "styled-components";
 
+import constructionMessage from "../../../pages/Under-Construction/message";
 import Alert from "../Alert";
 
 import { ReactComponent as PersonIcon } from "../../assets/ionic-md-person.svg";
@@ -165,10 +167,12 @@ function SlideOutMenu({ alertMessages, navLinks, toggleSlideOutMenu }) {
       <Menu tabIndex="0">
         <SearchBar>
           <form>
+            <ReactTooltip />
             <input
               type="search"
               placeholder={"Search gov.bc.ca"}
               ref={inputRef}
+              data-tip={constructionMessage}
             />
             <SearchButton
               onClick={(e) => {

--- a/react-app/src/pages/Home/Highlights.js
+++ b/react-app/src/pages/Home/Highlights.js
@@ -61,10 +61,10 @@ function Highlights({ highlights }) {
       {highlights?.map(({ icon, title, href }, index) => {
         return (
           <HighlightCard key={`highlight-${index}`}>
-            <Link to={href}>
+            <a href={href}>
               {icon && <Icon id={icon} />}
               {title && <h3>{title}</h3>}
-            </Link>
+            </a>
           </HighlightCard>
         );
       })}

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -1,9 +1,11 @@
 import React from "react";
 import MediaQuery from "react-responsive";
 import { Link } from "react-router-dom";
+import ReactTooltip from "react-tooltip";
 import styled from "styled-components";
 
 import Icon from "../../components/Icon";
+import constructionMessage from "../Under-Construction/message";
 
 const PersonalizationBlock = styled.div`
   background-color: #f2f2f2;
@@ -155,11 +157,13 @@ function Personalization({ personalization }) {
             <Column className={"personalization-search-column"}>
               {intro && <h2 className={"h2--intro-text"}>{intro}</h2>}
               <label for="personalization-input">looking for</label>
+              <ReactTooltip />
               <input
                 type="text"
                 className="input--personalization"
                 id="personalization-input"
                 name="personalization-input"
+                data-tip={constructionMessage}
               />
             </Column>
             {verticals?.length > 0 &&

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -7,10 +7,6 @@ import Icon from "../../components/Icon";
 
 const PersonalizationBlock = styled.div`
   background-color: #f2f2f2;
-  height: 380px;
-  left: 0;
-  position: absolute;
-  top: 180px;
   width: 100%;
 
   div.div--interior {
@@ -68,7 +64,7 @@ const PersonalizationBlock = styled.div`
       font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
       font-size: 18px;
       padding: 0;
-      width: 172px;
+      width: 200px;
     }
   }
 `;
@@ -76,8 +72,8 @@ const PersonalizationBlock = styled.div`
 const Column = styled.div`
   display: block;
   text-align: left;
-  min-width: 200px;
-  max-width: 230px;
+  max-width: 200px;
+  min-width: 180px;
 
   &.personalization-search-column {
     text-align: center;
@@ -98,7 +94,7 @@ const Column = styled.div`
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     padding: 0;
-    width: 172px;
+    width: 150px;
   }
 
   a {
@@ -191,9 +187,9 @@ function Personalization({ personalization }) {
                   </Column>
                 );
               })}
-            <Column>
+            {/* <Column>
               <Icon id={"homepage-right-arrow.svg"} />
-            </Column>
+            </Column> */}
           </div>
         </MediaQuery>
 
@@ -238,7 +234,7 @@ function Personalization({ personalization }) {
           </div>
         </MediaQuery>
       </PersonalizationBlock>
-      <Spacer />
+      {/* <Spacer /> */}
     </>
   );
 }

--- a/react-app/src/pages/Home/data.js
+++ b/react-app/src/pages/Home/data.js
@@ -85,22 +85,22 @@ const highlights = [
   {
     title: "Work in BC",
     icon: "material-work.svg",
-    href: "/under-construction",
+    href: "/#work-in-bc",
   },
   {
     title: "What's Happening",
     icon: "ionic-md-megaphone.svg",
-    href: "/under-construction",
+    href: "/#whats-happening",
   },
   {
     title: "In the News",
     icon: "newspaper-solid.svg",
-    href: "/under-construction",
+    href: "/#in-the-news",
   },
   {
     title: "Get Involved",
     icon: "hands-up.svg",
-    href: "/under-construction",
+    href: "/#get-involved",
   },
 ];
 

--- a/react-app/src/pages/Home/index.js
+++ b/react-app/src/pages/Home/index.js
@@ -1,9 +1,16 @@
 import React from "react";
+import styled from "styled-components";
 
 import Personalization from "./Personalization";
 import Highlights from "./Highlights";
 import Topics from "./Topics";
 import { personalization, highlights, topics } from "./data.js";
+
+const Section = styled.section`
+  @media (max-width: 575px) {
+    margin: 10px;
+  }
+`;
 
 function Home() {
   return (
@@ -18,12 +25,38 @@ function Home() {
       <Topics topics={topics} />
 
       {/* Work in BC full width block */}
+      <Section id="work-in-bc">
+        <h2>Work in BC</h2>
+        <p>Find a Job</p>
+        <p>View Current BC Government Jobs</p>
+        <p>MyHR</p>
+      </Section>
+      <br />
 
       {/* What's Happening */}
+      <Section id="whats-happening">
+        <h2>What's Happening</h2>
+        <p>BC's Economic Recovery Plan</p>
+        <p>BC's Response to COVID-19</p>
+      </Section>
+      <br />
 
       {/* In the News */}
+      <Section id="in-the-news">
+        <h2>In the News</h2>
+        <p>Daily Update on COVID-19</p>
+        <p>More news stories</p>
+      </Section>
+      <br />
 
       {/* Get Involved */}
+      <Section id="get-involved">
+        <h2>Get Involved</h2>
+        <p>Recycling Regulations Policy Intentions Paper</p>
+        <p>Rural Slaughter Modernization</p>
+        <p>View more public engagements</p>
+      </Section>
+      <br />
 
       {/* Footer */}
     </>

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -114,6 +114,7 @@ function ServicesContent() {
               name="search"
               onChange={onChangeHandler}
               value={inputValue}
+              autoComplete={"off"}
             />
           </label>
           <button disabled></button>

--- a/react-app/src/pages/Under-Construction/message.js
+++ b/react-app/src/pages/Under-Construction/message.js
@@ -1,0 +1,3 @@
+const message = "This feature hasn't been implemented yet";
+
+export default message;


### PR DESCRIPTION
This PR adds [react-tooltip](https://www.npmjs.com/package/react-tooltip) as a front-end dependency for displaying tooltip messages for features that are not yet built out. A site-wide message for this is added under `./src/pages/Under-Construction`. Tooltips with this message are added to the Header search bars (full screen and the slide-out menu).

Other updates:
- The Personalization component on the Homepage is set back to `position: static` rather than `absolute` for now because the entire page will need to be refactored for this block to appear full-width
- The Highlights section now hash-links (with `<a>` rather than `<Link>`) to sections further down the Homepage
- Autocomplete is turned off on the Services page search bar