### PR TITLE
Bugfix: Window scroll comparisons for Header states

### DIFF
--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -178,7 +178,9 @@ function Header({ alertMessages, navLinks, satellite, title }) {
   const MINIMUM_SCROLL = Math.round(window.innerHeight / 2);
 
   useDocumentScrollThrottled((callbackData) => {
-    const { previousScrollTop, currentScrollTop } = callbackData;
+    let { previousScrollTop, currentScrollTop } = callbackData;
+    previousScrollTop = Math.round(previousScrollTop);
+    currentScrollTop = Math.round(currentScrollTop);
     const isScrolledDown = previousScrollTop < currentScrollTop;
     const isMinimumScrolled = currentScrollTop > MINIMUM_SCROLL;
 


### PR DESCRIPTION
This PR uses `Math.round` on the `previousScrollTop` and `currentScrollTop` variables within the scrolling handler to prevent flashing rapidly between collapsed and full-width Header states. This is further to rounding the `MINIMUM_SCROLL` value in #74.