### PR TITLE
Bugfix: Header and SlideOutMenu positioning

### DIFF
--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -14,6 +14,7 @@ const Cover = styled.div`
   background: rgba(0, 0, 0, 0.7);
   height: 100vh;
   position: fixed;
+  top: 80px;
   width: 100%;
 `;
 

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -63,16 +63,10 @@ const Menu = styled.div`
           font-weight: 700;
           padding: 0;
 
-          div.slide-out-menu-li-navlink-arrow-body {
-            background-color: #fcba16;
-            display: inline-block;
-            height: 44px;
-            width: 4px;
-          }
           div.slide-out-menu-li-navlink-arrow-head {
             background-color: #fcba16;
             background-size: cover;
-            clip-path: polygon(0% 0%, 0% 100%, 50% 50%);
+            clip-path: polygon(0% 0%, 0% 100%, 50% 100%, 100% 50%, 50% 0%);
             display: inline-block;
             height: 44px;
             width: 10px;
@@ -80,7 +74,7 @@ const Menu = styled.div`
 
           div.slide-out-menu-li-navlink-text {
             display: inline-block;
-            padding-left: 2px;
+            padding-left: 6px;
           }
         }
       }
@@ -198,7 +192,6 @@ function SlideOutMenu({ alertMessages, navLinks, toggleSlideOutMenu }) {
                     activeClassName="slide-out-menu-li-navlink"
                     onClick={toggleSlideOutMenu}
                   >
-                    <div className="slide-out-menu-li-navlink-arrow-body"></div>
                     <div className="slide-out-menu-li-navlink-arrow-head"></div>
                     <div className="slide-out-menu-li-navlink-text">{text}</div>
                   </NavLink>

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -47,11 +47,8 @@ const NavStyled = styled.nav`
     height: 80px;
     text-decoration: none;
 
-    div.header-navlink-top {
-      height: 8px;
-    }
     div.header-navlink-arrow {
-      height: 7px;
+      height: 15px;
     }
     div.header-navlink-text {
       height: 50px;
@@ -70,7 +67,7 @@ const NavStyled = styled.nav`
     div.header-navlink-arrow {
       background-color: #fcba19;
       background-size: cover;
-      clip-path: polygon(0% 0%, 100% 0%, 50% 100%);
+      clip-path: polygon(0% 0%, 100% 0%, 100% 50%, 50% 100%, 0% 50%);
     }
   }
 
@@ -132,13 +129,11 @@ function Nav({ hidden, navLinks, toggleSearch, toggleSlideOutMenu }) {
             <li key={index}>
               {external ? (
                 <a href={href}>
-                  <div className="header-navlink-top"></div>
                   <div className="header-navlink-arrow"></div>
                   <div className="header-navlink-text">{text}</div>
                 </a>
               ) : (
                 <NavLink to={href} activeClassName="a--current-page">
-                  <div className="header-navlink-top"></div>
                   <div className="header-navlink-arrow"></div>
                   <div className="header-navlink-text">{text}</div>
                 </NavLink>

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -17,8 +17,9 @@ import { ReactComponent as BackToTopIcon } from "../assets/back-to-top.svg";
 
 const HeaderStyled = styled.header`
   background: none;
-  position: sticky;
+  position: fixed;
   top: 0;
+  width: 100%;
   z-index: 1;
 
   /* The left-collapsed header on desktop sizes at least 1271px wide */

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -9,19 +9,17 @@ import Breadcrumbs from "./Breadcrumbs";
 import { ReactComponent as ArrowLeft } from "./assets/arrow-left-solid.svg";
 
 const StyledPage = styled.div`
-  div#offset {
-    @media (max-width: 420px) {
-      margin-bottom: 190px;
-    }
-    @media (min-width: 421px) {
-      margin-bottom: 170px;
-    }
-    @media (min-width: 576px) {
-      margin-bottom: 150px;
-    }
-    @media (min-width: 768px) {
-      margin-bottom: 140px;
-    }
+  @media (max-width: 420px) {
+    margin-top: 190px;
+  }
+  @media (min-width: 421px) {
+    margin-top: 170px;
+  }
+  @media (min-width: 576px) {
+    margin-top: 150px;
+  }
+  @media (min-width: 768px) {
+    margin-top: 140px;
   }
 `;
 
@@ -128,10 +126,6 @@ function Page({
       <SkipToMainContentLink />
       <span id="main-content-anchor"></span>
       <Header title={title} />
-
-      {/* Used to offset the Header (position: fixed) height */}
-      <div id="offset" />
-
       {breadcrumbs && breadcrumbs.length > 0 && (
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       )}

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -8,6 +8,23 @@ import Breadcrumbs from "./Breadcrumbs";
 
 import { ReactComponent as ArrowLeft } from "./assets/arrow-left-solid.svg";
 
+const StyledPage = styled.div`
+  div#offset {
+    @media (max-width: 420px) {
+      margin-bottom: 190px;
+    }
+    @media (min-width: 421px) {
+      margin-bottom: 170px;
+    }
+    @media (min-width: 576px) {
+      margin-bottom: 150px;
+    }
+    @media (min-width: 768px) {
+      margin-bottom: 140px;
+    }
+  }
+`;
+
 const StyledSkipLink = styled.a`
   color: white;
   display: hidden;
@@ -107,10 +124,14 @@ function Page({
   parentTitle = "",
 }) {
   return (
-    <>
+    <StyledPage>
       <SkipToMainContentLink />
       <span id="main-content-anchor"></span>
       <Header title={title} />
+
+      {/* Used to offset the Header (position: fixed) height */}
+      <div id="offset" />
+
       {breadcrumbs && breadcrumbs.length > 0 && (
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       )}
@@ -122,7 +143,7 @@ function Page({
         />
         {content}
       </main>
-    </>
+    </StyledPage>
   );
 }
 


### PR DESCRIPTION
This PR makes two updates to the Header component to prevent unexpected layout expansion/contraction:

1. SlideOutMenu component within the Header has `top` spacing set explicitly to prevent the menu from appearing further down the page than necessary in unexpected Header states.

2. The Header itself is set to `position: fixed` rather than `sticky` for better cross-browser support and to prevent minor variations in appearance based on scroll position. As a result of taking the Header out of the page flow, the page content needs to be pushed down below the height of the Header. This is accomplished with a series of media queries in the Page component that set a `margin-top` based on the screen width. This is not super robust as it does not take into account very long site-wide Alerts, but it will simplify the design research testing with the current app content.

Additionally, the `react-router-dom` NavLink styling in the Header and SlideOutMenu is updated to remove extraneous `<div>`s by extending the `clip-path` polygons visually.