### PR TITLE
Check for environment before running postinstall script

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -41,7 +41,7 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "postinstall": "cd .. && husky install react-app/.husky"
+    "postinstall": "[ \"$NODE_ENV\" != production ] && cd .. && husky install react-app/.husky"
   },
   "engines": {
     "node": ">=14.0.0",


### PR DESCRIPTION
Heroku deployment fails with new `husky` v5 config as we are running a non-standard setup with `./react-app/package.json` in a different directory from `.git`. This PR updates the `postinstall` script in the `./react-app/package.json` to check for `NODE_ENV != production` so it doesn't run on Heroku.