### PR TITLE
Homepage Personalization block search functionality

### DIFF
--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -1,20 +1,18 @@
 import React from "react";
+import Highlighter from "react-highlight-words";
 import MediaQuery from "react-responsive";
 import { Link } from "react-router-dom";
-import ReactTooltip from "react-tooltip";
 import styled from "styled-components";
-
-import Icon from "../../components/Icon";
-import constructionMessage from "../Under-Construction/message";
 
 const PersonalizationBlock = styled.div`
   background-color: #f2f2f2;
+  min-height: 272px;
   width: 100%;
 
   div.div--interior {
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
+    justify-content: flex-start;
     margin: 0 auto;
     padding: 20px 0;
 
@@ -68,6 +66,10 @@ const PersonalizationBlock = styled.div`
       padding: 0;
       width: 200px;
     }
+  }
+
+  .text--highlighted {
+    background-color: #fcba19;
   }
 `;
 
@@ -145,8 +147,20 @@ const Spacer = styled.div`
   height: 420px;
 `;
 
-function Personalization({ personalization }) {
+function Personalization({ personalization, parentCallback, searchTerm }) {
   const { id, intro, verticals } = personalization;
+
+  // If there are matches in a vertical's children for a given search term,
+  // include that vertical in filteredVerticals
+  const filteredVerticals = verticals.filter((vertical) => {
+    const filteredChildren = vertical?.children?.filter((child) => {
+      return child?.label?.toLowerCase().includes(searchTerm.toLowerCase())
+        ? true
+        : false;
+    });
+
+    return filteredChildren.length > 0 ? true : false;
+  });
 
   return (
     <>
@@ -157,17 +171,21 @@ function Personalization({ personalization }) {
             <Column className={"personalization-search-column"}>
               {intro && <h2 className={"h2--intro-text"}>{intro}</h2>}
               <label for="personalization-input">looking for</label>
-              <ReactTooltip />
               <input
                 type="text"
+                autoComplete="off"
                 className="input--personalization"
                 id="personalization-input"
                 name="personalization-input"
-                data-tip={constructionMessage}
+                onChange={(e) => {
+                  parentCallback(e.target.value);
+                }}
               />
             </Column>
-            {verticals?.length > 0 &&
-              verticals.map(({ id, href, title, children }, index) => {
+
+            {/* Show only the verticals that have been filtered */}
+            {filteredVerticals?.length > 0 &&
+              filteredVerticals.map(({ id, href, title, children }, index) => {
                 return (
                   <Column key={`personalization-column-${id ? id : index}`}>
                     {title && href && (
@@ -175,13 +193,23 @@ function Personalization({ personalization }) {
                         <h3>{title}</h3>
                       </Link>
                     )}
+
+                    {/* Display all child links for a vertical and
+                    highlight those that match searchTerm */}
                     {children?.length > 0 && (
                       <ul>
                         {children.map(
                           ({ href: childHref, label }, childIndex) => {
                             return (
                               <li key={`column-${id}-li-${childIndex}`}>
-                                <Link to={childHref}>{label}</Link>
+                                <Link to={childHref}>
+                                  <Highlighter
+                                    highlightClassName="text--highlighted"
+                                    searchWords={[searchTerm]}
+                                    autoEscape={true}
+                                    textToHighlight={label}
+                                  />
+                                </Link>
                               </li>
                             );
                           }
@@ -204,14 +232,18 @@ function Personalization({ personalization }) {
             <label for="personalization-input">looking for</label>
             <input
               type="text"
+              autoComplete="off"
               className="input--personalization"
               id="personalization-input"
               name="personalization-input"
+              onChange={(e) => {
+                parentCallback(e.target.value);
+              }}
             />
           </div>
           <div className={"div--interior div--interior-mobile"}>
-            {verticals?.length > 0 &&
-              verticals.map(({ id, href, title, children }, index) => {
+            {filteredVerticals?.length > 0 &&
+              filteredVerticals.map(({ id, href, title, children }, index) => {
                 return (
                   <Column key={`personalization-column-${id ? id : index}`}>
                     {title && href && (
@@ -225,7 +257,14 @@ function Personalization({ personalization }) {
                           ({ href: childHref, label }, childIndex) => {
                             return (
                               <li key={`column-${id}-li-${childIndex}`}>
-                                <Link to={childHref}>{label}</Link>
+                                <Link to={childHref}>
+                                  <Highlighter
+                                    highlightClassName="text--highlighted"
+                                    searchWords={[searchTerm]}
+                                    autoEscape={true}
+                                    textToHighlight={label}
+                                  />
+                                </Link>
                               </li>
                             );
                           }

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Highlighter from "react-highlight-words";
-import MediaQuery from "react-responsive";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -9,13 +8,13 @@ const PersonalizationBlock = styled.div`
   min-height: 272px;
   width: 100%;
 
-  div.div--interior {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    margin: 0 auto;
-    padding: 20px 0;
+  div.div--container {
+    display: inline-block;
+    vertical-align: top;
 
+    @media (max-width: 575px) {
+      width: 100%;
+    }
     @media (min-width: 576px) {
       width: 100%;
     }
@@ -23,35 +22,54 @@ const PersonalizationBlock = styled.div`
       width: 728px;
     }
     @media (min-width: 992px) {
-      width: 952px;
+      width: 752px;
+    }
+
+    div.div--flex {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      margin: 0 auto;
+      padding: 20px 0;
+
+      @media (max-width: 767px) {
+        overflow-x: auto;
+        width: 100%;
+
+        /* Hide scrollbar */
+        -ms-overflow-style: none; /* Internet Explorer 10+ */
+        scrollbar-width: none; /* Firefox */
+        &::-webkit-scrollbar {
+          display: none; /* Chrome, Safari */
+        }
+      }
     }
   }
+`;
 
-  div.div--interior-mobile {
-    justify-content: flex-start;
-    overflow-x: auto;
+const SearchBlock = styled.div`
+  display: inline-block;
+  text-align: center;
+  vertical-align: center;
+  width: 200px;
+
+  @media (max-width: 991px) {
+    display: block;
     width: 100%;
-
-    /* Hide scrollbar */
-    -ms-overflow-style: none; /* Internet Explorer 10+ */
-    scrollbar-width: none; /* Firefox */
-    &::-webkit-scrollbar {
-      display: none; /* Chrome, Safari */
-    }
-
-    @media (min-width: 576px) {
-      width: 100%;
-    }
-    @media (min-width: 768px) {
-      width: 728px;
-    }
-    @media (min-width: 992px) {
-      width: 952px;
-    }
   }
 
-  div.personalization-search-horizontal {
-    text-align: center;
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    h2 {
+      display: block;
+
+      @media (min-width: 992px) {
+        margin-top: 40px;
+      }
+    }
 
     label {
       display: none;
@@ -61,45 +79,24 @@ const PersonalizationBlock = styled.div`
       background: none;
       border: none;
       border-bottom: 1px solid #313132;
+      border-radius: 0;
       font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
       font-size: 18px;
       padding: 0;
-      width: 200px;
-    }
-  }
+      width: 150px;
 
-  .text--highlighted {
-    background-color: #fcba19;
+      @media (max-width: 991px) {
+        width: 200px;
+      }
+    }
   }
 `;
 
 const Column = styled.div`
   display: block;
   text-align: left;
-  max-width: 200px;
+  max-width: 190px;
   min-width: 180px;
-
-  &.personalization-search-column {
-    text-align: center;
-  }
-
-  h2.h2--intro-text {
-    display: block;
-  }
-
-  label {
-    display: none;
-  }
-
-  input[type="text"].input--personalization {
-    background: none;
-    border: none;
-    border-bottom: 1px solid #313132;
-    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
-    font-size: 18px;
-    padding: 0;
-    width: 150px;
-  }
 
   a {
     color: #313132;
@@ -141,8 +138,14 @@ const Column = styled.div`
     height: 100px;
     margin-top: 16px;
   }
+
+  .text--highlighted {
+    background-color: #fcba19;
+  }
 `;
 
+// If a full width block with position: absolute is used for full screen
+// width, a Spacer div should be used to push the rest of the content down
 const Spacer = styled.div`
   height: 420px;
 `;
@@ -163,122 +166,71 @@ function Personalization({ personalization, parentCallback, searchTerm }) {
   });
 
   return (
-    <>
-      <PersonalizationBlock id={id}>
-        {/* Desktop, show all columns with search column on left */}
-        <MediaQuery minWidth={576}>
-          <div className={"div--interior"}>
-            <Column className={"personalization-search-column"}>
-              {intro && <h2 className={"h2--intro-text"}>{intro}</h2>}
-              <label for="personalization-input">looking for</label>
-              <input
-                type="text"
-                autoComplete="off"
-                className="input--personalization"
-                id="personalization-input"
-                name="personalization-input"
-                onChange={(e) => {
-                  parentCallback(e.target.value);
-                }}
-              />
-            </Column>
+    <PersonalizationBlock id={id}>
+      {/* Desktop: SearchBlock appears as a left column
+      Mobile: SearchBlock appears as a full width row above the columns */}
+      <SearchBlock>
+        <div>
+          {intro && <h2>{intro}</h2>}
+          <label for="personalization-input">looking for</label>
+          <input
+            type="text"
+            autoComplete="off"
+            id="personalization-input"
+            name="personalization-input"
+            onChange={(e) => {
+              parentCallback(e.target.value);
+            }}
+          />
+        </div>
+      </SearchBlock>
 
-            {/* Show only the verticals that have been filtered */}
-            {filteredVerticals?.length > 0 &&
-              filteredVerticals.map(({ id, href, title, children }, index) => {
-                return (
-                  <Column key={`personalization-column-${id ? id : index}`}>
-                    {title && href && (
-                      <Link to={href}>
-                        <h3>{title}</h3>
-                      </Link>
-                    )}
+      <div className={"div--container"}>
+        <div className={"div--flex"}>
+          {/* Show only the verticals that have been filtered */}
+          {filteredVerticals?.length > 0 &&
+            filteredVerticals.map(({ id, href, title, children }, index) => {
+              return (
+                <Column key={`personalization-column-${id ? id : index}`}>
+                  {title && href && (
+                    <Link to={href}>
+                      <h3>{title}</h3>
+                    </Link>
+                  )}
 
-                    {/* Display all child links for a vertical and
-                    highlight those that match searchTerm */}
-                    {children?.length > 0 && (
-                      <ul>
-                        {children.map(
-                          ({ href: childHref, label }, childIndex) => {
-                            return (
-                              <li key={`column-${id}-li-${childIndex}`}>
-                                <Link to={childHref}>
-                                  <Highlighter
-                                    highlightClassName="text--highlighted"
-                                    searchWords={[searchTerm]}
-                                    autoEscape={true}
-                                    textToHighlight={label}
-                                  />
-                                </Link>
-                              </li>
-                            );
-                          }
-                        )}
-                      </ul>
-                    )}
-                  </Column>
-                );
-              })}
-            {/* <Column>
-              <Icon id={"homepage-right-arrow.svg"} />
-            </Column> */}
-          </div>
-        </MediaQuery>
+                  {/* Display all child links for a vertical and
+                  highlight those that match searchTerm */}
+                  {children?.length > 0 && (
+                    <ul>
+                      {children.map(
+                        ({ href: childHref, label }, childIndex) => {
+                          return (
+                            <li key={`column-${id}-li-${childIndex}`}>
+                              <Link to={childHref}>
+                                <Highlighter
+                                  highlightClassName="text--highlighted"
+                                  searchWords={[searchTerm]}
+                                  autoEscape={true}
+                                  textToHighlight={label}
+                                />
+                              </Link>
+                            </li>
+                          );
+                        }
+                      )}
+                    </ul>
+                  )}
+                </Column>
+              );
+            })}
 
-        {/* Mobile, show search bar on top and columns with horizontal scroll below */}
-        <MediaQuery maxWidth={575}>
-          <div className={"personalization-search-horizontal"}>
-            {intro && <h2 className={"h2--intro-text"}>{intro}</h2>}
-            <label for="personalization-input">looking for</label>
-            <input
-              type="text"
-              autoComplete="off"
-              className="input--personalization"
-              id="personalization-input"
-              name="personalization-input"
-              onChange={(e) => {
-                parentCallback(e.target.value);
-              }}
-            />
-          </div>
-          <div className={"div--interior div--interior-mobile"}>
-            {filteredVerticals?.length > 0 &&
-              filteredVerticals.map(({ id, href, title, children }, index) => {
-                return (
-                  <Column key={`personalization-column-${id ? id : index}`}>
-                    {title && href && (
-                      <Link to={href}>
-                        <h3>{title}</h3>
-                      </Link>
-                    )}
-                    {children?.length > 0 && (
-                      <ul>
-                        {children.map(
-                          ({ href: childHref, label }, childIndex) => {
-                            return (
-                              <li key={`column-${id}-li-${childIndex}`}>
-                                <Link to={childHref}>
-                                  <Highlighter
-                                    highlightClassName="text--highlighted"
-                                    searchWords={[searchTerm]}
-                                    autoEscape={true}
-                                    textToHighlight={label}
-                                  />
-                                </Link>
-                              </li>
-                            );
-                          }
-                        )}
-                      </ul>
-                    )}
-                  </Column>
-                );
-              })}
-          </div>
-        </MediaQuery>
-      </PersonalizationBlock>
-      {/* <Spacer /> */}
-    </>
+          {/* Right arrow to display more columns */}
+          {/* <Column>
+            <Icon id={"homepage-right-arrow.svg"} />
+          </Column> */}
+        </div>
+      </div>
+    </PersonalizationBlock>
   );
 }
 

--- a/react-app/src/pages/Home/index.js
+++ b/react-app/src/pages/Home/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import Personalization from "./Personalization";
@@ -13,10 +13,20 @@ const Section = styled.section`
 `;
 
 function Home() {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  function handleSearchInput(inputValue) {
+    setSearchTerm(inputValue);
+  }
+
   return (
     <>
       {/* Full width block personalization block */}
-      <Personalization personalization={personalization} />
+      <Personalization
+        parentCallback={handleSearchInput}
+        personalization={personalization}
+        searchTerm={searchTerm}
+      />
 
       {/* 4 highlight tiles with larger icons */}
       <Highlights highlights={highlights} />


### PR DESCRIPTION
This PR adds search filtering and highlighting to the input box in the Personalization block within the Homepage. The `searchTerm` state is kept at the Homepage level in case it will be required for filtering Topics cards or other items later. This gets updates with `onChange` on the text input field.

The `react-highlight-words` dependency is used similarly to the Services page and Navigation component to highlight items that match the `searchTerm`. Content verticals with no matching links are filtered out of view until the `searchTerm` state changes to a match (or empty string).

Within the Personalization block, this PR removes `<MediaQuery>` usage so that the input box is not removed from the DOM unexpectedly, causing the `searchTerm` to enter a weird state with no visible search entered but links still filtered/highlighted.