### PR TITLE
Education content updates

### DIFF
--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 const PersonalizationBlock = styled.div`
   background-color: #f2f2f2;
-  min-height: 272px;
+  min-height: 300px;
   width: 100%;
 
   div.div--container {

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/data.js
@@ -47,6 +47,9 @@ const content = [
     children: "Costs",
   },
   {
+    type: "br",
+  },
+  {
     type: "h3",
     id: "are-you-a-current-student",
     children: "Are you a current student?",
@@ -62,222 +65,106 @@ const content = [
     ],
   },
   {
-    type: "radio-button-group",
-    id: "current-student-radio-group",
-    title: "",
-    defaultContent: [
+    type: "br",
+  },
+  {
+    type: "h3",
+    id: "current-students",
+    children: "Current students",
+  },
+  {
+    type: "p",
+    children: [
       {
-        type: "h3",
-        id: "default-current-students",
-        children: "Current students",
+        type: "text",
+        children: "As a current student, you get for free",
       },
+    ],
+  },
+  {
+    type: "ul",
+    children: [
       {
-        type: "p",
+        type: "li",
         children: [
           {
-            type: "text",
-            children: "As a current student, you get for free",
-          },
-        ],
-      },
-      {
-        type: "ul",
-        children: [
-          {
-            type: "li",
+            type: "p",
             children: [
               {
-                type: "p",
-                children: [
-                  {
-                    type: "text",
-                    children:
-                      "up to 25 transcripts sent to post-secondary institutions on your behalf",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            type: "li",
-            children: [
-              {
-                type: "p",
-                children: [
-                  {
-                    type: "text",
-                    children:
-                      "one printed, mailed transcript sent to a third party (e.g. to yourself or an employer)",
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            type: "li",
-            children: [
-              {
-                type: "p",
-                children: [
-                  {
-                    type: "text",
-                    children:
-                      "one graduation certificate from your school (once you have met graduation requirements)",
-                  },
-                ],
+                type: "text",
+                children:
+                  "up to 25 transcripts sent to post-secondary institutions on your behalf",
               },
             ],
           },
         ],
       },
       {
-        type: "p",
+        type: "li",
         children: [
           {
-            type: "text",
-            children: "Any additional transcripts are $10 each.",
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "one printed, mailed transcript sent to a third party (e.g. to yourself or an employer)",
+              },
+            ],
           },
         ],
       },
       {
-        type: "br",
-      },
-      {
-        type: "h3",
-        id: "default-former-students",
-        children: "Former students",
-      },
-      {
-        type: "p",
+        type: "li",
         children: [
           {
-            type: "text",
-            children:
-              "For former students, ordering transcripts and certificates are ",
-          },
-          {
-            type: "text",
-            style: "strong",
-            children: "$10 each",
-          },
-          {
-            type: "text",
-            children:
-              ". Once your request is received, you will be sent a confirmation e-mail.",
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "one graduation certificate from your school (once you have met graduation requirements)",
+              },
+            ],
           },
         ],
       },
     ],
+  },
+  {
+    type: "p",
     children: [
       {
-        id: "yes",
-        label: "Yes",
-        body: [
-          {
-            type: "h3",
-            id: "current-students",
-            children: "Current students",
-          },
-          {
-            type: "p",
-            children: [
-              {
-                type: "text",
-                children: "As a current student, you get for free",
-              },
-            ],
-          },
-          {
-            type: "ul",
-            children: [
-              {
-                type: "li",
-                children: [
-                  {
-                    type: "p",
-                    children: [
-                      {
-                        type: "text",
-                        children:
-                          "up to 25 transcripts sent to post-secondary institutions on your behalf",
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                type: "li",
-                children: [
-                  {
-                    type: "p",
-                    children: [
-                      {
-                        type: "text",
-                        children:
-                          "one printed, mailed transcript sent to a third party (e.g. to yourself or an employer)",
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                type: "li",
-                children: [
-                  {
-                    type: "p",
-                    children: [
-                      {
-                        type: "text",
-                        children:
-                          "one graduation certificate from your school (once you have met graduation requirements)",
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            type: "p",
-            children: [
-              {
-                type: "text",
-                children: "Any additional transcripts are $10 each.",
-              },
-            ],
-          },
-        ],
+        type: "text",
+        children: "Any additional transcripts are $10 each.",
+      },
+    ],
+  },
+  {
+    type: "br",
+  },
+  {
+    type: "h3",
+    id: "former-students",
+    children: "Former students",
+  },
+  {
+    type: "p",
+    children: [
+      {
+        type: "text",
+        children:
+          "For former students, ordering transcripts and certificates are ",
       },
       {
-        id: "no",
-        label: "No",
-        body: [
-          {
-            type: "h3",
-            id: "former-students",
-            children: "Former students",
-          },
-          {
-            type: "p",
-            children: [
-              {
-                type: "text",
-                children:
-                  "For former students, ordering transcripts and certificates are ",
-              },
-              {
-                type: "text",
-                style: "strong",
-                children: "$10 each",
-              },
-              {
-                type: "text",
-                children:
-                  ". Once your request is received, you will be sent a confirmation e-mail.",
-              },
-            ],
-          },
-        ],
+        type: "text",
+        style: "strong",
+        children: "$10 each",
+      },
+      {
+        type: "text",
+        children:
+          ". Once your request is received, you will be sent a confirmation e-mail.",
       },
     ],
   },

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/data.js
@@ -58,7 +58,8 @@ const content = [
         },
       },
       grade1012bc: {
-        question_text: "Did you take any grade 10 to 12 courses in B.C.?",
+        question_text:
+          "Did you take any grade 10 to 12 courses in B.C. or Yukon?",
         options: [
           {
             label: "Yes",

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
@@ -75,7 +75,7 @@ const content = [
       {
         type: "text",
         children:
-          "Transcripts A transcript is an official listing of your secondary school (high school) marks and credits received specific to a British Columbia Graduation Program.",
+          "A transcript is an official listing of your secondary school (high school) marks and credits received specific to a British Columbia Graduation Program.",
       },
     ],
   },

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/data.js
@@ -2,6 +2,9 @@ const content = [
   {
     type: "navigation",
     id: "education-and-training-navigation",
+    search: {
+      label: "Search Support",
+    },
     children: [
       {
         cards: [

--- a/react-app/src/pages/Themes/Education-and-Training/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/data.js
@@ -33,7 +33,8 @@ const content = [
           {
             title: "Transcripts and Certificates",
             cardLink: {
-              href: "/under-construction",
+              href:
+                "/themes/education-and-training/k-12/support/transcripts-and-certificates",
               external: false,
             },
             description: [
@@ -106,7 +107,8 @@ const content = [
                 label: "COVID-19 safe schools",
               },
               {
-                href: "/under-construction",
+                href:
+                  "/themes/education-and-training/k-12/support/transcripts-and-certificates",
                 label: "StudentTranscripts Service",
               },
             ],


### PR DESCRIPTION
This PR includes the following Education content branch updates:
- The "Education and Training" navigation page has links to the "Transcripts and Certificates" page added to the "Transcripts and Certificates" card and the "StudentTranscripts Service" quick link on the "K-12" card
- The "Eligibility" page has its wizard content updated to reference Yukon transcripts
- The radio button content group on the "Costs" page is refactored into simple paragraph content rather than radio button content
- A SearchBar component is added to the "Support" navigation page
- The "Transcripts and Certificates" page has a typo fixed

Additionally:
- The Personalization block has its `min-height` updated to 300px