### PR TITLE
Add SearchBar to TableGroup

### DIFF
--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -72,7 +72,9 @@ function SearchBar({ parentCallback, placeHolder }) {
           value={inputValue}
           placeholder={placeHolder}
         />
-        <SearchButton>
+        <SearchButton
+          disabled={true} // For now, all search buttons are just decorative
+        >
           <SearchIcon />
         </SearchButton>
       </form>

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { textService } from "../_services/text.service";
 import Icon from "./Icon";
+import SearchBar from "./SearchBar";
 
 const StyledTable = styled.table`
   border-collapse: collapse;
@@ -55,6 +56,7 @@ const StyledFilters = styled.div`
 `;
 
 function TableGroup({ context = {}, data, id }) {
+  const [searchTerm, setSearchTerm] = useState("");
   const [sortConfig, setSortConfig] = useState(data?.sortConfig || {});
   const [filterConfig, setFilterConfig] = useState(
     data?.filter?.initial || context?.filterConfig || {}
@@ -62,6 +64,11 @@ function TableGroup({ context = {}, data, id }) {
   const [viewConfig, setViewConfig] = useState(
     data?.view?.initial || context?.viewConfig || {}
   );
+
+  // Set the searchTerm state
+  function handleSearchInput(input) {
+    setSearchTerm(input);
+  }
 
   // Set the filterConfig state
   function handleFilter(id, value) {
@@ -96,11 +103,12 @@ function TableGroup({ context = {}, data, id }) {
     }
   }
 
-  // Check if the given table row should be displayed based on filterConfig
+  // Check if table row should be shown based on filterConfig and searchTerm
   function checkFilter(row) {
     const keys = Object.keys(filterConfig);
     let pass = [];
 
+    // Check row's filter data against filterConfig state
     for (const key in keys) {
       if (row.filter && keys[key] in row.filter) {
         if (row.filter[keys[key]].indexOf(filterConfig[keys[key]]) !== -1) {
@@ -108,6 +116,15 @@ function TableGroup({ context = {}, data, id }) {
         } else {
           pass.push(false);
         }
+      } else {
+        pass.push(false);
+      }
+    }
+
+    // Check row's plaintext data against searchTerm state (if applicable)
+    if (data?.search && searchTerm) {
+      if (row?.plaintext?.toLowerCase().includes(searchTerm.toLowerCase())) {
+        pass.push(true);
       } else {
         pass.push(false);
       }
@@ -236,6 +253,13 @@ function TableGroup({ context = {}, data, id }) {
 
   return (
     <>
+      {data?.search && (
+        <SearchBar
+          parentCallback={handleSearchInput}
+          placeHolder={data?.search?.placeHolder || "Search"}
+        />
+      )}
+
       <StyledFilters>
         {data?.filter?.children?.length > 0 &&
           data.filter.children.map((child, index) => {
@@ -290,7 +314,7 @@ function TableGroup({ context = {}, data, id }) {
 
 const StyledRadioFilterGroup = styled.form`
   display: inline-block;
-  margin: 0 0 40px 0;
+  margin: 40px 0;
 
   @media (max-width: 575px) {
     width: 100%;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
@@ -3,6 +3,9 @@ const content = [
     type: "table-group",
     id: "forms-table",
     data: {
+      search: {
+        placeHolder: "Search Forms",
+      },
       sortConfig: {
         id: "form-number",
         direction: "ascending",
@@ -87,6 +90,8 @@ const content = [
                 },
                 tbody: [
                   {
+                    plaintext:
+                      "Residential Tenancy Agreement for Internet Explorer, RTB-1",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                     },
@@ -163,6 +168,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Residential Tenancy Agreement for other browsers, RTB-1C",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -237,6 +244,7 @@ const content = [
                     ],
                   },
                   {
+                    plaintext: "Application for Review Consideration, RTB-2",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -310,6 +318,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Manufactured Home Site Tenancy Agreement, RTB-5",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -383,6 +393,7 @@ const content = [
                     ],
                   },
                   {
+                    plaintext: "Request for Correction, RTB-6",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -455,6 +466,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Notice of Rent Increase - Residential Rental Units, RTB-7",
                     filter: {
                       "sort-forms-for": ["all", "landlords"],
                       "view-forms-by": ["list"],
@@ -543,6 +556,7 @@ const content = [
                     ],
                   },
                   {
+                    plaintext: "Mutual Agreement to End a Tenancy, RTB-8",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -615,6 +629,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Proof of Service Notice of Expedited Hearing, RTB-9",
                     filter: {
                       "sort-forms-for": ["all", "landlords", "tenants"],
                       "view-forms-by": ["list"],
@@ -687,6 +703,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Request for Consent to Assign a Manufactured Home Site Tenancy Agreement, RTB-10",
                     filter: {
                       "sort-forms-for": ["all", "tenants"],
                       "view-forms-by": ["list"],
@@ -760,6 +778,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Notice of Rent Increase - Manufactured Home Site - (auto-calculating version), RTB-11A",
                     filter: {
                       "sort-forms-for": ["all", "landlords"],
                       "view-forms-by": ["list"],
@@ -889,6 +909,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Landlord Application for Dispute Resolution - Current Tenancy, RTB-12L-CT",
                     filter: {
                       "sort-forms-for": ["all", "landlords"],
                       "view-forms-by": ["list"],
@@ -963,6 +985,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Landlord Application for Dispute Resolution - Past Tenancy, RTB-12L-PT",
                     filter: {
                       "sort-forms-for": ["all", "landlords"],
                       "view-forms-by": ["list"],
@@ -1037,6 +1061,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Tenant Application for Dispute Resolution - Current Tenancy, RTB-12T-CT",
                     filter: {
                       "sort-forms-for": ["all", "tenants"],
                       "view-forms-by": ["list"],
@@ -1111,6 +1137,8 @@ const content = [
                     ],
                   },
                   {
+                    plaintext:
+                      "Tenant Application for Dispute Resolution - Past Tenancy, RTB-12T-PT",
                     filter: {
                       "sort-forms-for": ["all", "tenants"],
                       "view-forms-by": ["list"],
@@ -1231,6 +1259,8 @@ const content = [
                   },
                   tbody: [
                     {
+                      plaintext:
+                        "Proof of Service Notice of Expedited Hearing, RTB-9",
                       filter: {
                         "sort-forms-for": ["all", "landlords", "tenants"],
                       },
@@ -1306,6 +1336,8 @@ const content = [
                       ],
                     },
                     {
+                      plaintext:
+                        "Landlord Application for Dispute Resolution - Current Tenancy, RTB-12L-CT",
                       filter: {
                         "sort-forms-for": ["all", "landlords"],
                         "view-forms-by": ["type"],
@@ -1380,6 +1412,8 @@ const content = [
                       ],
                     },
                     {
+                      plaintext:
+                        "Landlord Application for Dispute Resolution - Past Tenancy, RTB-12L-PT",
                       filter: {
                         "sort-forms-for": ["all", "landlords"],
                         "view-forms-by": ["type"],
@@ -1454,6 +1488,8 @@ const content = [
                       ],
                     },
                     {
+                      plaintext:
+                        "Tenant Application for Dispute Resolution - Current Tenancy, RTB-12T-CT",
                       filter: {
                         "sort-forms-for": ["all", "tenants"],
                         "view-forms-by": ["type"],
@@ -1528,6 +1564,8 @@ const content = [
                       ],
                     },
                     {
+                      plaintext:
+                        "Tenant Application for Dispute Resolution - Past Tenancy, RTB-12T-PT",
                       filter: {
                         "sort-forms-for": ["all", "tenants"],
                         "view-forms-by": ["type"],


### PR DESCRIPTION
This PR adds the SearchBar component to the TableGroup component, allowing filtering rows of the child tables based on text field input. For now, there is no Highlighter functionality compared to similar searchable components like Navigation, due to the complexity of the table row content.

Additionally, the search button in the SearchBar component is disabled app-wide, as there is no functionality for this button currently, and it may become a decorative image as opposed to a functional button.