### PR TITLE
Bugfix: Make buttons use pointer cursor

### DIFF
--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -17,6 +17,7 @@ const AccordionHeader = styled.div`
     align-items: center;
     background: none;
     border: none;
+    cursor: pointer;
     display: flex;
     justify-content: space-between;
     min-height: 44px;
@@ -106,6 +107,8 @@ const MoreInfoHeader = styled.div`
   button.button--more-info {
     background: none;
     border: 0;
+    color: #1a5a96;
+    cursor: pointer;
     display: block;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
@@ -115,14 +118,20 @@ const MoreInfoHeader = styled.div`
     padding: 0;
 
     span {
-      color: #1a5a96;
       text-decoration: underline;
     }
 
     svg {
-      color: #1a5a96;
       margin-left: 7px;
       width: 14px;
+    }
+
+    &:hover {
+      color: blue;
+
+      span {
+        text-decoration: none;
+      }
     }
   }
 `;

--- a/react-app/src/components/Header/Alert/index.js
+++ b/react-app/src/components/Header/Alert/index.js
@@ -23,15 +23,12 @@ const StyledAlert = styled.div`
   &.alert-hidden {
     display: block;
     float: right;
-    /* height: 69px; */ // If this is taller than the alert, the header collapse-on-scroll feature will break
     height: 43px;
     margin-right: 36px;
     text-align: center;
-    /* width: 62px; */
     width: 44px;
 
     svg.svg--info {
-      /* padding: 23px 13px 10px 13px; */
       padding: 0;
     }
     div.div--alert {
@@ -73,6 +70,7 @@ const StyledAlert = styled.div`
   button {
     border: none;
     background: none;
+    cursor: pointer;
     min-height: 44px;
     padding: 0;
     min-width: 44px;

--- a/react-app/src/components/Header/Nav/LanguagePicker.js
+++ b/react-app/src/components/Header/Nav/LanguagePicker.js
@@ -17,6 +17,7 @@ const LanguagePickerStyled = styled.div`
     background: none;
     border: 0;
     color: #313132;
+    cursor: pointer;
     display: flex;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;

--- a/react-app/src/components/Header/Nav/UserPanel.js
+++ b/react-app/src/components/Header/Nav/UserPanel.js
@@ -17,6 +17,7 @@ const UserPanelStyled = styled.div`
     background: none;
     border: 0;
     color: #313132;
+    cursor: pointer;
     display: flex;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -77,6 +77,7 @@ const NavStyled = styled.nav`
     border: 0;
     box-sizing: border-box;
     color: #888888;
+    cursor: pointer;
     display: flex;
     flex-direction: column;
     height: 80px;

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -113,6 +113,7 @@ const HeaderStyled = styled.header`
     appearance: none;
     background: none;
     border: 0;
+    cursor: pointer;
     padding: 0;
     text-decoration: none;
     width: 44px;
@@ -130,6 +131,7 @@ const HeaderStyled = styled.header`
   div.wrapper > div.div--header-mini-icons > button#menu-icon {
     background-color: #f2f2f2;
     color: #888888;
+    cursor: pointer;
     height: 100%;
     min-height: 44px;
   }
@@ -148,6 +150,7 @@ const HeaderStyled = styled.header`
   button#button--back-to-top {
     background: none;
     border: none;
+    cursor: pointer;
     height: 44px;
     padding: 0;
     position: fixed;

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -25,6 +25,7 @@ const StyledTable = styled.table`
         background: none;
         border: 0;
         color: #313132;
+        cursor: pointer;
         font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
         font-size: 20px;
         font-weight: 700;
@@ -32,11 +33,21 @@ const StyledTable = styled.table`
         margin: 0 0 8px 0;
         padding: 0;
 
+        &:hover {
+          color: blue;
+          text-decoration: underline;
+        }
+
         &.sorted {
           color: #1a5a96;
           text-decoration: underline;
           text-decoration-thickness: 1px;
           text-underline-offset: 2px;
+
+          &:hover {
+            color: blue;
+            text-decoration: none;
+          }
         }
 
         svg {
@@ -361,6 +372,7 @@ const StyledRadioFilterGroup = styled.form`
           align-items: center;
           border: 1px solid transparent;
           border-radius: 10px;
+          cursor: pointer;
           display: flex;
           font-size: 18px;
           justify-content: space-around;
@@ -431,6 +443,7 @@ const AccordionHeader = styled.div`
     align-items: center;
     background: none;
     border: none;
+    cursor: pointer;
     display: flex;
     justify-content: space-between;
     min-height: 44px;


### PR DESCRIPTION
This PR updates buttons in the following components to use `cursor: pointer` for a more obvious indication that they are clickable elements:

- Accordion and MoreInfo
- Alert
- Header
  - Nav
  - UserPanel
  - LanguagePicker
- TableGroup (table headings, radio button groups, accordion components)