### PR TITLE
Extend Wizard with content based on state

### DIFF
--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -39,6 +39,7 @@ function sanitize(input) {
  *   - @param {*} children - a string for primitive elements,
  *                           or an array or for composed elements
  *                           like `p`, `span`, or React components
+ *   - @param {array} contentBlocks - content arrays in stateful components
  *   - @param {object} data - JSON object data for React components
  *   - @param {object} args - arbitrary arguments for React components
  *   - @param {object} search - search bar configuration for Reach components
@@ -46,7 +47,7 @@ function sanitize(input) {
  *   - @param {string} first - ID of the first step in stepped component
  *   - @param {object} steps - JSON representation of steps in stepped component
  *   - @param {object} callToAction - primary action in a stepped component
- *   - @param {object} defaultContent - show before selection in radio component
+ *   - @param {array} defaultContent - content array shown in default/unselected state
  *   - @param {string} placeHolder - placeHolder text for text inputs
  *   - @param {string} href - the `href` of an `a` tag, the `to` of a Link
  *   - @param {Boolean} primary - primary Boolean for Button components
@@ -62,6 +63,7 @@ function buildHtmlElement(
     style,
     className,
     children,
+    contentBlocks,
     data,
     args,
     search,
@@ -454,6 +456,8 @@ function buildHtmlElement(
       return (
         <Wizard
           key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          contentBlocks={contentBlocks}
+          defaultContent={defaultContent}
           first={first}
           steps={steps}
           title={title}

--- a/react-app/src/_utils/__tests__/shallowEqual.test.js
+++ b/react-app/src/_utils/__tests__/shallowEqual.test.js
@@ -1,0 +1,55 @@
+// Test cases from https://github.com/facebook/fbjs/
+
+jest.unmock("shallowEqual");
+
+import shallowEqual from "../shallowEqual";
+
+describe("shallowEqual", () => {
+  it("returns false if either argument is null", () => {
+    expect(shallowEqual(null, {})).toBe(false);
+    expect(shallowEqual({}, null)).toBe(false);
+  });
+
+  it("returns true if both arguments are null or undefined", () => {
+    expect(shallowEqual(null, null)).toBe(true);
+    expect(shallowEqual(undefined, undefined)).toBe(true);
+  });
+
+  it("returns true if arguments are not objects and are equal", () => {
+    expect(shallowEqual(1, 1)).toBe(true);
+  });
+
+  it("returns true if arguments are shallow equal", () => {
+    expect(shallowEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 })).toBe(true);
+  });
+
+  it("returns true when comparing NaN", () => {
+    expect(shallowEqual(NaN, NaN)).toBe(true);
+
+    expect(
+      shallowEqual({ a: 1, b: 2, c: 3, d: NaN }, { a: 1, b: 2, c: 3, d: NaN })
+    ).toBe(true);
+  });
+
+  it("returns false if arguments are not objects and not equal", () => {
+    expect(shallowEqual(1, 2)).toBe(false);
+  });
+
+  it("returns false if only one argument is not an object", () => {
+    expect(shallowEqual(1, {})).toBe(false);
+  });
+
+  it("returns false if first argument has too many keys", () => {
+    expect(shallowEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it("returns false if second argument has too many keys", () => {
+    expect(shallowEqual({ a: 1, b: 2 }, { a: 1, b: 2, c: 3 })).toBe(false);
+  });
+
+  it("returns false if arguments are not shallow equal", () => {
+    expect(shallowEqual({ a: 1, b: 2, c: {} }, { a: 1, b: 2, c: {} })).toBe(
+      false
+    );
+  });
+});

--- a/react-app/src/_utils/__tests__/shallowEqual.test.js
+++ b/react-app/src/_utils/__tests__/shallowEqual.test.js
@@ -1,7 +1,5 @@
 // Test cases from https://github.com/facebook/fbjs/
 
-jest.unmock("shallowEqual");
-
 import shallowEqual from "../shallowEqual";
 
 describe("shallowEqual", () => {

--- a/react-app/src/_utils/shallowEqual.js
+++ b/react-app/src/_utils/shallowEqual.js
@@ -1,0 +1,70 @@
+/*eslint-disable no-self-compare */
+
+/**
+ * Object.is() polyfill for Internet Explorer, from:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#polyfill
+ */
+if (!Object.is) {
+  Object.defineProperty(Object, "is", {
+    value: function (x, y) {
+      // SameValue algorithm
+      if (x === y) {
+        // Return true if x and y are not 0, OR
+        // if x and y are both 0 of the same sign.
+        return x !== 0 || 1 / x === 1 / y;
+      } else {
+        // Return true if both x AND y evaluate to NaN.
+        // The only possibility for a variable to not be strictly equal to itself
+        // is when that variable evaluates to NaN (example: Number.NaN, 0/0, NaN).
+        return x !== x && y !== y;
+      }
+    },
+  });
+}
+
+/**
+ * Compare two objects for shallow equivalence. Primitive types are compared for
+ * equivalance, objects are only compared by reference (not deepEqual).
+ * Edge cases from Facebook shallowEqual:
+ * https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/shallowEqual.js
+ * @param {object} obj1
+ * @param {object} obj2
+ */
+function shallowEqual(obj1, obj2) {
+  // Return true early if native Object.is() passes
+  if (Object.is(obj1, obj2)) {
+    return true;
+  }
+
+  // Check for non-object types
+  if (
+    typeof obj1 !== "object" ||
+    obj1 === null ||
+    typeof obj2 !== "object" ||
+    obj2 === null
+  ) {
+    return false;
+  }
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  // Check for length of object key arrays
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  // Check for value of each key in object
+  for (let i = 0; i < keys1.length; i++) {
+    if (
+      !hasOwnProperty.call(obj2, keys1[i]) ||
+      !Object.is(obj1[keys1[i]], obj2[keys1[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = shallowEqual;

--- a/react-app/src/components/Wizard.js
+++ b/react-app/src/components/Wizard.js
@@ -149,8 +149,9 @@ function Wizard({
         };
       });
 
-      // If no next step is explicitly set, use the state data
-      // to see what the radio button option has set for the next step.
+      // If no next step is explicitly set by the step control button,
+      // use the state data to see what the radio button option has set for the
+      // next step.
     } else if (step?.options?.length > 0) {
       const newContent = [];
 
@@ -167,6 +168,8 @@ function Wizard({
         newContent.push(...defaultContent);
       }
 
+      // Add the option's next_step to the top of the
+      // stepsShown stack to go to the next step
       step.options.forEach((option) => {
         if (option["id"] === state.data[currentStep]) {
           setState((currentState) => {
@@ -180,7 +183,9 @@ function Wizard({
         }
       });
 
-      // Reset the wizard at first step with no state data or explanation
+      // With no forward step set explicitly by the forward button or by the
+      // selected option, and no `back` argument, reset the wizard to the
+      // first step with blank data and explanation, and show defaultContent.
     } else {
       setState(() => {
         return {
@@ -246,6 +251,17 @@ function Wizard({
           {step?.text?.length > 0 &&
             step.text.map((object, index) => {
               return textService.buildHtmlElement(object, index);
+            })}
+
+          {/* Text specific to one step which changes based on Wizard state */}
+          {step.conditionalText?.length > 0 &&
+            step.conditionalText.map(({ displayState, contentArray }) => {
+              return (
+                shallowEqual(state.data, displayState) &&
+                contentArray.map((object, index) => {
+                  return textService.buildHtmlElement(object, index);
+                })
+              );
             })}
 
           <div className="div--wizard-questionnaire">

--- a/react-app/src/components/Wizard.js
+++ b/react-app/src/components/Wizard.js
@@ -2,9 +2,14 @@ import React, { useState } from "react";
 import styled from "styled-components";
 
 import { textService } from "../_services/text.service";
+import shallowEqual from "../_utils/shallowEqual";
 import { Button } from "./Button";
 
 const StyledWizard = styled.div`
+  display: block;
+`;
+
+const Questionnaire = styled.div`
   background-color: #f2f2f2;
   margin-bottom: 20px;
   padding: 18px 26px;
@@ -88,10 +93,21 @@ const StyledWizard = styled.div`
   }
 `;
 
-function Wizard({ title, first, steps }) {
+const Information = styled.div`
+  display: block;
+`;
+
+function Wizard({
+  title,
+  first,
+  steps,
+  defaultContent = [],
+  contentBlocks = [],
+}) {
   const [stepsShown, setStepsShown] = useState([first]);
   const [data, setData] = useState({});
   const [explanation, setExplanation] = useState([]);
+  const [content, setContent] = useState(defaultContent || []);
 
   const step = steps[stepsShown[0]];
 
@@ -101,8 +117,7 @@ function Wizard({ title, first, steps }) {
    * @param {Boolean} back - if true, we're stepping backwards
    */
   function handleStep(currentStep, nextStep, back) {
-    // On back button click, remove the current step from stepsShown,
-    // and set state data for this step to undefined to disable forward button.
+    // On back button click, remove the current step from stepsShown
     if (back === true) {
       setStepsShown((steps) => {
         if (stepsShown.length === 2) {
@@ -114,7 +129,7 @@ function Wizard({ title, first, steps }) {
       });
       onDataChange(stepsShown[0], null, null);
 
-      // If the next step is explicitly set by the step control, show it.
+      // If the next step is explicitly set by the step control button, show it
     } else if (nextStep) {
       setStepsShown((steps) => [nextStep, ...steps]);
       setExplanation([]);
@@ -129,12 +144,15 @@ function Wizard({ title, first, steps }) {
         }
       });
 
-      // If we're not going back or forward, we're restarting.
+      // Reset the wizard at first step with no state data or explanation
     } else {
       setStepsShown(() => [first]);
       setData({});
       setExplanation([]);
     }
+
+    // Update content after each step movement
+    updateContent();
   }
 
   /**
@@ -143,7 +161,19 @@ function Wizard({ title, first, steps }) {
    * @param {object} option - the `option` object with `text` array for explanation
    */
   function onDataChange(dataKey, dataValue, option) {
-    setData({ ...data, [dataKey]: dataValue });
+    const existingData = { ...data };
+
+    if (dataValue !== null) {
+      // Non-null values indicate a new option has been selected
+      setData({ ...existingData, [dataKey]: dataValue });
+    } else {
+      // Null values indicate the back button has been pressed and
+      // we should remove the corresponding key from the state data object
+      delete existingData[dataKey];
+      setData({ ...existingData });
+    }
+
+    // Set explanation (text that appears visually within Questionnaire)
     if (option?.text?.length > 0) {
       setExplanation(option.text);
     } else {
@@ -151,93 +181,126 @@ function Wizard({ title, first, steps }) {
     }
   }
 
+  // Update page content that appears visually below grey Questionnaire
+  function updateContent() {
+    let stateMatch = false;
+
+    contentBlocks.forEach(({ displayState, contentArray }) => {
+      // Update content if state data object shallow equals
+      // contentBlock displayState configuration
+      if (shallowEqual(data, displayState)) {
+        stateMatch = true;
+        setContent(() => contentArray);
+      }
+    });
+
+    // If there are no contentBlock matches, show defaultContent
+    if (!stateMatch) {
+      setContent(() => defaultContent);
+    }
+  }
+
   return (
     <StyledWizard>
-      {title && <h2>{title}</h2>}
-      <div className="div--wizard-container">
-        {/* Introductory/question text that appears above radio options */}
-        {step?.text?.length > 0 &&
-          step.text.map((object, index) => {
-            return textService.buildHtmlElement(object, index);
-          })}
+      <Questionnaire>
+        {title && <h2>{title}</h2>}
+        <div className="div--wizard-container">
+          {/* Introductory/question text that appears above radio options */}
+          {step?.text?.length > 0 &&
+            step.text.map((object, index) => {
+              return textService.buildHtmlElement(object, index);
+            })}
 
-        <div className="div--wizard-questionnaire">
-          <div className="div--wizard-question">
-            {step?.options?.length > 0 &&
-              step.options.map((option, index) => {
-                return (
-                  <div
-                    className="div--wizard-input"
-                    key={`wizard-input-${index}`}
-                  >
-                    <input
-                      type="radio"
-                      id={`wizard-input-${option.id}`}
-                      name={stepsShown[0]}
-                      value={option.id}
-                      checked={data?.[stepsShown[0]] === option.id}
-                      onChange={(e) => {
-                        onDataChange(stepsShown[0], e.target.value, option);
-                      }}
-                    />
-                    <label htmlFor={`wizard-input-${option.id}`}>
-                      {option.label}
-                    </label>
-                  </div>
-                );
-              })}
+          <div className="div--wizard-questionnaire">
+            <div className="div--wizard-question">
+              {step?.options?.length > 0 &&
+                step.options.map((option, index) => {
+                  return (
+                    <div
+                      className="div--wizard-input"
+                      key={`wizard-input-${index}`}
+                    >
+                      <input
+                        type="radio"
+                        id={`wizard-input-${option.id}`}
+                        name={stepsShown[0]}
+                        value={option.id}
+                        checked={data?.[stepsShown[0]] === option.id}
+                        onChange={(e) => {
+                          onDataChange(stepsShown[0], e.target.value, option);
+                        }}
+                      />
+                      <label htmlFor={`wizard-input-${option.id}`}>
+                        {option.label}
+                      </label>
+                    </div>
+                  );
+                })}
+            </div>
+
+            {/* Explanatory text for a selected option that appears either
+            to the right of or below the options depending on screen width */}
+            {explanation?.length > 0 && (
+              <div className="div--wizard-explanation">
+                {explanation.map((object, index) => {
+                  return textService.buildHtmlElement(object, index);
+                })}
+              </div>
+            )}
           </div>
 
-          {/* Explanatory text that appears either to the right of or below the
-          radio options, depending on screen width */}
-          {explanation?.length > 0 && (
-            <div className="div--wizard-explanation">
-              {explanation.map((object, index) => {
-                return textService.buildHtmlElement(object, index);
-              })}
-            </div>
-          )}
+          <div className="div--wizard-controls">
+            {step?.controls?.back && (
+              <Button
+                label={step.controls.back.label}
+                primary={step.controls.back.primary}
+                onClick={() => {
+                  handleStep(stepsShown[0], step.controls.back.step, true);
+                }}
+              >
+                {step.controls.back.label}
+              </Button>
+            )}
+            {step?.controls?.forward && (
+              <Button
+                disabled={
+                  data.hasOwnProperty(stepsShown[0]) ||
+                  step.controls.forward?.step
+                    ? false
+                    : true
+                }
+                label={step.controls.forward.label}
+                primary={step.controls.forward.primary}
+                onClick={() => {
+                  handleStep(stepsShown[0], step.controls.forward.step);
+                }}
+              >
+                {step.controls.forward.label}
+              </Button>
+            )}
+            {step?.controls?.restart && (
+              <Button
+                label={step.controls.restart.label}
+                primary={step.controls.restart.primary}
+                onClick={() => {
+                  handleStep(stepsShown[0], step.controls.restart.step);
+                }}
+              >
+                {step.controls.restart.label}
+              </Button>
+            )}
+          </div>
         </div>
+      </Questionnaire>
 
-        <div className="div--wizard-controls">
-          {step?.controls?.back && (
-            <Button
-              label={step.controls.back.label}
-              primary={step.controls.back.primary}
-              onClick={() => {
-                handleStep(stepsShown[0], step.controls.back.step, true);
-              }}
-            >
-              {step.controls.back.label}
-            </Button>
-          )}
-          {step?.controls?.forward && (
-            <Button
-              disabled={
-                data[stepsShown[0]] || step.controls.forward.step ? false : true
-              }
-              label={step.controls.forward.label}
-              primary={step.controls.forward.primary}
-              onClick={() => {
-                handleStep(stepsShown[0], step.controls.forward.step);
-              }}
-            >
-              {step.controls.forward.label}
-            </Button>
-          )}
-          {step?.controls?.restart && (
-            <Button
-              label={step.controls.restart.label}
-              primary={step.controls.restart.primary}
-              onClick={() => {
-                handleStep(stepsShown[0], step.controls.restart.step);
-              }}
-            >
-              {step.controls.restart.label}
-            </Button>
-          )}
-        </div>
-      </div>
+      {/* Page content that can be swapped based on component state */}
+      {content?.length > 0 && (
+        <Information>
+          {content.map((object, index) => {
+            return textService.buildHtmlElement(object, index);
+          })}
+        </Information>
+      )}
     </StyledWizard>
   );
 }

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
@@ -1,5 +1,3 @@
-import KindergartenToGrade12 from "../..";
-
 const content = [
   {
     type: "tabbed-page-nav",

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
@@ -115,9 +115,50 @@ const content = [
             children: [
               {
                 type: "text",
-                style: "strong",
                 children:
                   "The information below has been curated to match your selections.",
+              },
+            ],
+          },
+        ],
+        conditionalText: [
+          {
+            displayState: {
+              age: "12-to-14-years",
+              entertainmentIndustry: "yes",
+            },
+            contentArray: [
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children: "View below information relevant to:",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children: "A child at the age of ",
+                  },
+                  {
+                    type: "text",
+                    style: "strong",
+                    children: "12 -14 years old",
+                  },
+                  {
+                    type: "text",
+                    children: " working in the ",
+                  },
+                  {
+                    type: "text",
+                    style: "strong",
+                    children: "entertainment industry",
+                  },
+                ],
               },
             ],
           },
@@ -130,181 +171,474 @@ const content = [
         },
       },
     },
-  },
-  {
-    type: "tabbed-page-nav",
-    children: [
+    defaultContent: [
       {
-        label: "Hiring Under 15 Years Old",
-        href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people",
-      },
-      {
-        label: "Hiring young people in the entertainment industry",
-        href:
-          "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people/entertainment-industry",
-      },
-    ],
-  },
-  {
-    type: "br",
-  },
-  {
-    type: "p",
-    className: "p--last-updated",
-    children: [
-      {
-        type: "text",
-        style: "normal",
-        children: "Last Updated: December 12, 2020",
-      },
-    ],
-  },
-  {
-    type: "br",
-  },
-  {
-    type: "on-this-page",
-    title: "On This Page",
-    children: [
-      {
-        id: "hiring-under-15-years-old",
-        label: "Hiring Under 15 Years Old",
-      },
-      {
-        id: "contact-the-employment-standards-branch",
-        label: "Contact the Employment Standards Branch",
-      },
-    ],
-  },
-  {
-    type: "br",
-  },
-  {
-    type: "h2",
-    id: "hiring-under-15-years-old",
-    children: "Hiring Under 15 Years Old",
-  },
-  {
-    type: "callout",
-    children: [
-      {
-        type: "p",
+        type: "tabbed-page-nav",
         children: [
           {
-            type: "text",
-            children:
-              "Employers need permission to hire a child under 15 years old",
+            label: "Hiring Under 15 Years Old",
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people",
+          },
+          {
+            label: "Hiring young people in the entertainment industry",
+            href:
+              "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/hiring-employees/hiring-young-people/entertainment-industry",
           },
         ],
       },
-    ],
-  },
-  {
-    type: "p",
-    children: [
       {
-        type: "text",
-        children:
-          "A parent or guardian decides if it’s in the best interests of their child to have a job. They must provide written permission for their child to work.",
+        type: "br",
       },
-    ],
-  },
-  {
-    type: "p",
-    children: [
       {
-        type: "text",
-        children:
-          "Employers must keep a record of the written consent. It needs to include the child’s date of birth and confirmation that the child’s parent or guardian agrees to the hours, location and type of work the child will be doing.",
+        type: "p",
+        className: "p--last-updated",
+        children: [
+          {
+            type: "text",
+            style: "normal",
+            children: "Last Updated: December 12, 2020",
+          },
+        ],
       },
-    ],
-  },
-  {
-    type: "br",
-  },
-  {
-    type: "tabbed-content",
-    children: [
       {
-        label: "Hiring 15 years and older",
-        body: [
+        type: "br",
+      },
+      {
+        type: "on-this-page",
+        title: "On This Page",
+        children: [
+          {
+            id: "hiring-under-15-years-old",
+            label: "Hiring Under 15 Years Old",
+          },
+          {
+            id: "contact-the-employment-standards-branch",
+            label: "Contact the Employment Standards Branch",
+          },
+        ],
+      },
+      {
+        type: "br",
+      },
+      {
+        type: "h2",
+        id: "hiring-under-15-years-old",
+        children: "Hiring Under 15 Years Old",
+      },
+      {
+        type: "callout",
+        children: [
           {
             type: "p",
             children: [
               {
                 type: "text",
                 children:
-                  "Employers who hire a young person who is 15 years of age or older must:",
+                  "Employers need permission to hire a child under 15 years old",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            children:
+              "A parent or guardian decides if it’s in the best interests of their child to have a job. They must provide written permission for their child to work.",
+          },
+        ],
+      },
+      {
+        type: "p",
+        children: [
+          {
+            type: "text",
+            children:
+              "Employers must keep a record of the written consent. It needs to include the child’s date of birth and confirmation that the child’s parent or guardian agrees to the hours, location and type of work the child will be doing.",
+          },
+        ],
+      },
+      {
+        type: "br",
+      },
+      {
+        type: "tabbed-content",
+        children: [
+          {
+            label: "Hiring 15 years and older",
+            body: [
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children:
+                      "Employers who hire a young person who is 15 years of age or older must:",
+                  },
+                ],
+              },
+              {
+                type: "ul",
+                children: [
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children: "Follow ",
+                          },
+                          {
+                            type: "a-internal",
+                            href: "/under-construction",
+                            children:
+                              "employment standards for regular employees",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children: "Meet ",
+                          },
+                          {
+                            type: "a-internal",
+                            href: "/under-construction",
+                            children:
+                              "WorkSafeBC requirements for young workers",
+                          },
+                          {
+                            type: "text",
+                            children: " (under 25 years old)",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children: "Make any required ",
+                          },
+                          {
+                            type: "a-internal",
+                            href: "/under-construction",
+                            children: "federal payroll deductions",
+                          },
+                          {
+                            type: "text",
+                            children:
+                              " like income tax and Employment Insurance premiums",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },
           {
-            type: "ul",
-            children: [
+            label: "Rules Hiring ages 12-14",
+            body: [
               {
-                type: "li",
+                type: "p",
                 children: [
                   {
-                    type: "p",
+                    type: "text",
+                    style: "strong",
+                    children: "Get Parent or Guardian Consent",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children: "Employers ",
+                  },
+                  {
+                    type: "a-internal",
+                    href: "/under-construction",
+                    children:
+                      "need written consent from a parent or guardian (PDF, 20 KB)",
+                  },
+                  {
+                    type: "text",
+                    children: ".",
+                  },
+                ],
+              },
+              {
+                type: "br",
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    style: "strong",
+                    children: "Work Hours",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children: "Children who are 12 to 14 years old cannot:",
+                  },
+                ],
+              },
+              {
+                type: "ul",
+                children: [
+                  {
+                    type: "li",
                     children: [
                       {
-                        type: "text",
-                        children: "Follow ",
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children: "Be required to work during school hours",
+                          },
+                        ],
                       },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
                       {
-                        type: "a-internal",
-                        href: "/under-construction",
-                        children: "employment standards for regular employees",
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Work more than four hours on school days",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Work more than seven hours on a non-school day",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Work more than 20 hours during a week with five school days",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Work more than 35 hours a week when school is not in session",
+                          },
+                        ],
                       },
                     ],
                   },
                 ],
               },
               {
-                type: "li",
+                type: "br",
+              },
+              {
+                type: "p",
                 children: [
                   {
-                    type: "p",
+                    type: "text",
+                    style: "strong",
+                    children: "Provide Adult Supervision",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children:
+                      "Employees who are 12 to 14 years old must always be under the direct and immediate supervision of an adult.",
+                  },
+                ],
+              },
+              {
+                type: "br",
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    style: "strong",
+                    children: "Protect the Child’s Best Interest",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children:
+                      "Parents or guardians need to make sure the child’s employment is in their best interests. They need to:",
+                  },
+                ],
+              },
+              {
+                type: "ul",
+                children: [
+                  {
+                    type: "li",
                     children: [
                       {
-                        type: "text",
-                        children: "Meet ",
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Protect the child from work that could be unsafe, interrupt their education or harm their development",
+                          },
+                        ],
                       },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
                       {
-                        type: "a-internal",
-                        href: "/under-construction",
-                        children: "WorkSafeBC requirements for young workers",
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Make sure the child understands what’s expected of them",
+                          },
+                        ],
                       },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
                       {
-                        type: "text",
-                        children: " (under 25 years old)",
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children: "Make sure the child can do the job",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "li",
+                    children: [
+                      {
+                        type: "p",
+                        children: [
+                          {
+                            type: "text",
+                            children:
+                              "Act as a liaison between their child and other workers",
+                          },
+                        ],
                       },
                     ],
                   },
                 ],
               },
+            ],
+          },
+          {
+            label: "Rules Hiring under 12 years old",
+            body: [
               {
-                type: "li",
+                type: "p",
                 children: [
                   {
-                    type: "p",
-                    children: [
-                      {
-                        type: "text",
-                        children: "Make any required ",
-                      },
-                      {
-                        type: "a-internal",
-                        href: "/under-construction",
-                        children: "federal payroll deductions",
-                      },
-                      {
-                        type: "text",
-                        children:
-                          " like income tax and Employment Insurance premiums",
-                      },
-                    ],
+                    type: "text",
+                    children: "Employers need to complete an ",
+                  },
+                  {
+                    type: "a-internal",
+                    href: "/under-construction",
+                    children:
+                      "Application of Employer for Child’s Permit of Employment (PDF, 32.2KB)",
+                  },
+                  {
+                    type: "text",
+                    children:
+                      ". The child’s parent or guardian and school authority also complete sections of the application form.",
+                  },
+                ],
+              },
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children:
+                      "Send the application and a copy of the child’s birth certificate to the ",
+                  },
+                  {
+                    type: "a-internal",
+                    href: "/under-construction",
+                    children: "Victoria Employment Standards Branch office",
+                  },
+                  {
+                    type: "text",
+                    children: ".",
                   },
                 ],
               },
@@ -312,9 +646,97 @@ const content = [
           },
         ],
       },
+    ],
+    contentBlocks: [
       {
-        label: "Rules Hiring ages 12-14",
-        body: [
+        displayState: {
+          age: "12-to-14-years",
+          entertainmentIndustry: "yes",
+        },
+        contentArray: [
+          {
+            type: "br",
+          },
+          {
+            type: "p",
+            className: "p--last-updated",
+            children: [
+              {
+                type: "text",
+                style: "normal",
+                children: "Last Updated: December 12, 2020",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "on-this-page",
+            title: "On This Page",
+            children: [
+              {
+                id: "rules-hiring-ages-12-14",
+                label: "Rules Hiring Ages 12-14",
+              },
+              {
+                id: "specific-rules-hiring-for-the-entertainment-industry",
+                label: "Specific rules Hiring for the Entertainment Industry",
+              },
+              {
+                id: "employers-need-permission",
+                label: "Employers Need Permission",
+              },
+              {
+                id: "dont-leave-your-child-unsupervised",
+                label: "Don't leave your children unsupervised",
+              },
+              {
+                id: "hours-of-work",
+                label: "Hours of work",
+              },
+              {
+                id: "contact-the-employment-standards-branch",
+                label: "Contact the Employment Standards Branch",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h2",
+            id: "rules-hiring-ages-12-14",
+            children: "Rules Hiring Ages 12-14",
+          },
+          {
+            type: "callout",
+            children: [
+              {
+                type: "p",
+                children: [
+                  {
+                    type: "text",
+                    children:
+                      "Employers need permission to hire a child under 15 years old",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "A parent or guardian decides if it’s in the best interests of their child to have a job. They must provide written permission for their child to work.",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
           {
             type: "p",
             children: [
@@ -554,28 +976,48 @@ const content = [
               },
             ],
           },
-        ],
-      },
-      {
-        label: "Rules Hiring under 12 years old",
-        body: [
+          {
+            type: "br",
+          },
+          {
+            type: "h2",
+            id: "specific-rules-hiring-for-the-entertainment-industry",
+            children: "Specific Rule Hiring for the Entertainment Industry",
+          },
           {
             type: "p",
             children: [
               {
                 type: "text",
-                children: "Employers need to complete an ",
+                children:
+                  "Special employment conditions are outlined for children that work in the entertainment industry because they may be very young and will likely work during school hours. If a young person works in the entertainment industry, but in a position other than an actor, background performer or extra, the general rules for employing young people apply.",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h2",
+            id: "employers-need-permission",
+            children: "Employers Need Permission",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "Employers need written ",
               },
               {
                 type: "a-internal",
                 href: "/under-construction",
-                children:
-                  "Application of Employer for Child’s Permit of Employment (PDF, 32.2KB)",
+                children: "consent from a parent or guardian (PDF, 30 KB)",
               },
               {
                 type: "text",
                 children:
-                  ". The child’s parent or guardian and school authority also complete sections of the application form.",
+                  " to hire a young person as an actor, performer (including background performer) or extra for film, radio, video, television, theatre, dance, music, opera or circus performances.",
               },
             ],
           },
@@ -585,18 +1027,220 @@ const content = [
               {
                 type: "text",
                 children:
-                  "Send the application and a copy of the child’s birth certificate to the ",
+                  "The employer (via the assistant director, casting director or talent agent) should explain to the parent or guardian what the role of their child will be.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "- ",
               },
               {
                 type: "a-internal",
                 href: "/under-construction",
-                children: "Victoria Employment Standards Branch office",
+                children:
+                  "Children in the Recorded Entertainment Industry - Part 7.1 Division 2",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children: "- ",
+              },
+              {
+                type: "a-internal",
+                href: "/under-construction",
+                children:
+                  "Children in the Live Entertainment Industry - Part 7.1 Division 3",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h2",
+            id: "dont-leave-your-child-unsupervised",
+            children: "Don't Leave Your Children Unsupervised",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "One of the child’s parents or guardians should be present to supervise the child at all times. If the parent can’t be present, an adult (over 19 years old) can be assigned as the child’s chaperone. The chaperone needs written permission from a parent or guardian that authorizes them to make decisions on behalf of the child. The chaperone cannot be the child’s employer, tutor, or an employee of the employer or tutor.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "The supervising adult should be present on the set within sight and sound of the child. The employer can provide an audio and visual monitor when filming scenes.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "For live entertainment",
               },
               {
                 type: "text",
-                children: ".",
+                children:
+                  ", up to three children can be assigned to one adult that is also working as an extra or background performer on the same production set. ",
               },
             ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "For recorded entertainment",
+              },
+              {
+                type: "text",
+                children:
+                  ", the ratio of children to supervising adults is five children per adult for children aged 12 to 15 years old.",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "h2",
+            id: "hours-of-work",
+            children: "Hours of Work",
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                children:
+                  "Work hours include time spent doing hair, makeup, wardrobe or fittings. Split shifts are not allowed. Children cannot work more than five days per week.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Work begins at call time",
+              },
+              {
+                type: "text",
+                children:
+                  ". The workday starts at the child’s call time or when they’re required to start work. The earliest work can start is 5 am.",
+              },
+            ],
+          },
+          {
+            type: "p",
+            children: [
+              {
+                type: "text",
+                style: "strong",
+                children: "Work ends at wrap time",
+              },
+              {
+                type: "text",
+                children:
+                  ". The end of the workday is when the young person is no longer wearing makeup or a costume. It may include travel time or time spent waiting for transportation. The latest a child can work is 10 pm if the next day is a school day or 12:30 am if the next day is not a school day. If school is not in session a child can work until 2 a.m.",
+              },
+            ],
+          },
+          {
+            type: "br",
+          },
+          {
+            type: "table-basic",
+            id: "esb-hiring-young-people-hours",
+            data: {
+              thead: [
+                {
+                  id: "age",
+                  label: "Age",
+                  colspan: 1,
+                  align: "left",
+                  width: "20",
+                },
+                {
+                  id: "maximum-hours-of-work",
+                  label: "Maximum hours of work",
+                  colspan: 1,
+                  align: "left",
+                  width: "30",
+                },
+                {
+                  id: "time-before-camera",
+                  label: "Time before camera",
+                  colspan: 1,
+                  align: "left",
+                  width: "50",
+                },
+              ],
+              tbody: [
+                {
+                  cols: [
+                    {
+                      id: "age",
+                      colspan: 1,
+                      align: "left",
+                      children: [
+                        {
+                          type: "text",
+                          children: "12-14 years old",
+                        },
+                      ],
+                    },
+                    {
+                      id: "maximum-hours-of-work",
+                      colspan: 1,
+                      align: "left",
+                      children: [
+                        {
+                          type: "text",
+                          children: "10 hours per day",
+                        },
+                      ],
+                    },
+                    {
+                      id: "time-before-camera",
+                      colspan: 1,
+                      align: "left",
+                      children: [
+                        {
+                          type: "text",
+                          children:
+                            "A minimum break of 10 minutes for every 60 consecutive minutes",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            type: "br",
           },
         ],
       },


### PR DESCRIPTION
This PR extends the existing Wizard component to add the ability to display content based on the state of the Wizard, as determined by a user's selections. The ESB "Hiring Young People" Wizard instance data is updated to take advantage of this new functionality. It can be seen in action by selecting the "age 12-14" and "entertainment industry" option.

- A `shallowEqual()` implementation is added to the front-end app to compare state objects for enabling conditionally rendered content
- Tests for `shallowEqual()` are included
- Wizard data objects now take a `contentBlocks` array argument with state objects/content array pairs for displaying page content visually below the grey Wizard enclosing box (in the new `<Information>` block)
- Wizard `step` objects take a `conditionalText` array argument with state objects/content array pairs for displaying content within the Wizard (in the `<Questionnaire>` block), as in the example of the last slide of the ESB "Hiring Young People" instance
- Wizard state is now maintained in a single object for simplicity. Previously this was accomplished with a number of different `useState()` hook variables, but because these variables were closely related and changed at the same time, synchronicity issues arose because React does not guarantee the order of operations in these state update/render cycles.