### PR TITLE
Accordion accessibility upgrades

### DIFF
--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -52,6 +52,7 @@ function sanitize(input) {
  *   - @param {string} href - the `href` of an `a` tag, the `to` of a Link
  *   - @param {Boolean} primary - primary Boolean for Button components
  *   - @param {Boolean} external - Boolean for indicating external links
+ *   - @param {number} headingLevel - integer for h1-6 section heading level
  * @param {number} index - array index for React keys if applicable
  * @param {number} childIndex - nested array index for React keys if applicable
  * @param {array} highlight - array of search/filter strings to be highlighted
@@ -76,6 +77,7 @@ function buildHtmlElement(
     href,
     primary,
     external,
+    headingLevel,
   },
   index = null,
   childIndex = null,
@@ -280,6 +282,7 @@ function buildHtmlElement(
         <Accordion
           key={`${type}-${index}${childIndex ? `-${childIndex}` : ""}`}
           className={className}
+          headingLevel={headingLevel}
           id={id}
           title={title}
         >

--- a/react-app/src/_services/text.service.js
+++ b/react-app/src/_services/text.service.js
@@ -374,7 +374,11 @@ function buildHtmlElement(
       );
     case "more-info":
       return (
-        <MoreInfo key={`${type}-${index}-${childIndex ? childIndex : null}`}>
+        <MoreInfo
+          key={`${type}-${index}-${childIndex ? childIndex : null}`}
+          id={id}
+          title={title}
+        >
           {children}
         </MoreInfo>
       );

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -76,8 +76,12 @@ function Accordion({ expanded = false, id, title, children }) {
   return (
     <StyledAccordion id={id}>
       <AccordionHeader>
-        <button onClick={toggleOpen}>
-          <h3>{title}</h3>
+        <button
+          onClick={toggleOpen}
+          aria-controls={`accordion-body-${id}`}
+          aria-expanded={open ? true : false}
+        >
+          <h3 id={`accordion-label-${id}`}>{title}</h3>
           {open ? (
             <Icon id={"ionic-ios-arrow-up.svg"} />
           ) : (
@@ -85,7 +89,12 @@ function Accordion({ expanded = false, id, title, children }) {
           )}
         </button>
       </AccordionHeader>
-      <AccordionBody className={open ? "open" : "closed"}>
+      <AccordionBody
+        className={open ? "open" : "closed"}
+        id={`accordion-body-${id}`}
+        aria-labelledby={`accordion-label-${id}`}
+        role="region"
+      >
         {children &&
           children.map((element, index) => {
             return textService.buildHtmlElement(element, index);

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -37,7 +37,12 @@ const AccordionHeader = styled.div`
       background-color: #ededed;
     }
 
-    h3 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
       color: #313132;
       display: inline-block;
       font-size: 20px;
@@ -74,7 +79,7 @@ const AccordionBody = styled.div`
 `;
 
 // Full page-width accordion component which can be linked to on-page
-function Accordion({ expanded = false, id, title, children }) {
+function Accordion({ expanded = false, id, headingLevel, title, children }) {
   const hashFragment = window.location.href.split("#")[1];
   const directlyLinked = Boolean(hashFragment && id && hashFragment === id);
 
@@ -86,6 +91,10 @@ function Accordion({ expanded = false, id, title, children }) {
     setOpen(!open);
   }
 
+  // Set section heading semantic level dynamically with headingLevel prop,
+  // default to <h3> if not specified.
+  const Heading = `h${headingLevel || 3}`;
+
   return (
     <StyledAccordion id={id}>
       <AccordionHeader>
@@ -94,7 +103,7 @@ function Accordion({ expanded = false, id, title, children }) {
           aria-controls={`accordion-body-${id}`}
           aria-expanded={open ? true : false}
         >
-          <h3 id={`accordion-label-${id}`}>{title}</h3>
+          <Heading id={`accordion-label-${id}`}>{title}</Heading>
           {open ? (
             <Icon id={"ionic-ios-arrow-up.svg"} />
           ) : (

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -117,10 +117,14 @@ function Accordion({ expanded = false, id, headingLevel, title, children }) {
         aria-labelledby={`accordion-label-${id}`}
         role="region"
       >
-        {children &&
-          children.map((element, index) => {
-            return textService.buildHtmlElement(element, index);
-          })}
+        {/* If the children prop is an array, use the text service to build it */}
+        {children?.length > 0
+          ? children.map((element, index) => {
+              return textService.buildHtmlElement(element, index);
+            })
+          : // When the children prop isn't an array, the contents will be
+            // injected by a parent component using an Accordion as a child
+            children}
       </AccordionBody>
     </StyledAccordion>
   );

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -78,8 +78,25 @@ const AccordionBody = styled.div`
   }
 `;
 
-// Full page-width accordion component which can be linked to on-page
-function Accordion({ expanded = false, id, headingLevel, title, children }) {
+/**
+ * Full page-width accordion component which can be linked to on-page
+ * @param {object} props
+ *   - @param {*} children - handles array and non-array values
+ *   - @param {string} className - used by `styled-components` to allow unique
+ *                                 styling by parent components
+ *   - @param {Boolean} expanded - is the Accordion open to start
+ *   - @param {string} id - used for parent <div> id and aria attributes
+ *   - @param {number} headingLevel - integer for specifying heading h1-h6
+ *   - @param {string} title - accordion heading title
+ */
+function Accordion({
+  children,
+  className,
+  expanded = false,
+  id,
+  headingLevel,
+  title,
+}) {
   const hashFragment = window.location.href.split("#")[1];
   const directlyLinked = Boolean(hashFragment && id && hashFragment === id);
 
@@ -96,7 +113,7 @@ function Accordion({ expanded = false, id, headingLevel, title, children }) {
   const Heading = `h${headingLevel || 3}`;
 
   return (
-    <StyledAccordion id={id}>
+    <StyledAccordion id={id} className={className}>
       <AccordionHeader>
         <button
           onClick={toggleOpen}

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -24,6 +24,19 @@ const AccordionHeader = styled.div`
     padding: 0;
     width: 100%;
 
+    :focus {
+      background-color: #ededed;
+      outline: 4px solid #3b99fc;
+
+      :hover {
+        background-color: #d1d1d1;
+      }
+    }
+
+    :hover {
+      background-color: #ededed;
+    }
+
     h3 {
       color: #313132;
       display: inline-block;

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -129,6 +129,10 @@ function Accordion({ expanded = false, id, headingLevel, title, children }) {
 const StyledMoreInfo = styled.div`
   display: block;
   margin: 0 0 13px 0;
+
+  @media (max-width: 575px) {
+    margin-left: 10px;
+  }
 `;
 
 const MoreInfoHeader = styled.div`
@@ -155,6 +159,15 @@ const MoreInfoHeader = styled.div`
     svg {
       margin-left: 7px;
       width: 14px;
+    }
+
+    &:focus {
+      color: blue;
+      outline: 4px solid #3b99fc;
+
+      span {
+        text-decoration: none;
+      }
     }
 
     &:hover {

--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -183,7 +183,7 @@ const MoreInfoBody = styled.div`
 `;
 
 // Minimal accordion-style component for use within Table cells
-function MoreInfo({ id, children }) {
+function MoreInfo({ id, children, title = "More info" }) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -194,8 +194,10 @@ function MoreInfo({ id, children }) {
           onClick={() => {
             setOpen(!open);
           }}
+          aria-controls={`more-info-body-${id}`}
+          aria-expanded={open ? true : false}
         >
-          <span>More info</span>
+          <span id={`more-info-label-${id}`}>{title}</span>
           {open ? (
             <Icon id={"sort-up-solid.svg"} />
           ) : (
@@ -203,7 +205,12 @@ function MoreInfo({ id, children }) {
           )}
         </button>
       </MoreInfoHeader>
-      <MoreInfoBody className={open ? "open" : "closed"}>
+      <MoreInfoBody
+        className={open ? "open" : "closed"}
+        id={`more-info-body-${id}`}
+        aria-labelledby={`more-info-label-${id}`}
+        role="region"
+      >
         {children &&
           children.map((element, index) => {
             return textService.buildHtmlElement(element, index);

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -35,8 +35,8 @@ const StyledButton = styled.button`
   }
 
   &:focus {
+    opacity: 0.8;
     outline: 4px solid #3b99fc;
-    outline-offset: 1px;
   }
 
   &:hover {
@@ -124,6 +124,11 @@ const StyledLink = styled.a`
     margin-right: 10px;
   }
 
+  &:focus {
+    opacity: 0.8;
+    outline: 4px solid #3b99fc;
+  }
+
   &:hover {
     background-color: #003366;
     color: white;
@@ -152,6 +157,11 @@ const StyledRouterLink = styled(Link)`
   @media (max-width: 575px) {
     margin-left: 10px;
     margin-right: 10px;
+  }
+
+  &:focus {
+    opacity: 0.8;
+    outline: 4px solid #3b99fc;
   }
 
   &:hover {

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 
 import { textService } from "../_services/text.service";
+import { Accordion } from "./Accordion";
 import Icon from "./Icon";
 import SearchBar from "./SearchBar";
 
@@ -64,6 +65,12 @@ const StyledFilters = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-between;
+`;
+
+const StyledAccordion = styled(Accordion)`
+  div.open {
+    margin: 26px 0;
+  }
 `;
 
 function TableGroup({ context = {}, data, id }) {
@@ -317,13 +324,13 @@ function TableGroup({ context = {}, data, id }) {
                   // Tables can be nested inside of Accordions
                   if (elem?.type !== "table") {
                     return (
-                      <Accordion
+                      <StyledAccordion
                         key={`accordion-table-${elem.id}`}
                         id={elem.id}
                         title={elem.title}
                       >
                         {getTable(elem.id, elem?.childTable?.data)}
-                      </Accordion>
+                      </StyledAccordion>
                     );
                   } else {
                     return getTable(elem.id, elem.data);
@@ -440,89 +447,6 @@ function RadioFilterGroup({ id, data, initial, parentCallback }) {
         </div>
       </fieldset>
     </StyledRadioFilterGroup>
-  );
-}
-
-const StyledAccordion = styled.div`
-  display: block;
-  margin-bottom: 5px;
-`;
-
-const AccordionHeader = styled.div`
-  background-color: #d1d1d1;
-  display: block;
-
-  button {
-    align-items: center;
-    background: none;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    min-height: 44px;
-    padding: 0;
-    width: 100%;
-
-    h3 {
-      color: #313132;
-      display: inline-block;
-      font-size: 20px;
-      font-weight: 700;
-      margin: 0 12px;
-      text-align: left;
-    }
-
-    svg {
-      display: inline-block;
-      margin: 4px 18px;
-      min-width: 36px;
-      width: 36px;
-    }
-  }
-`;
-
-const AccordionBody = styled.div`
-  background-color: white;
-  font-size: 18px;
-
-  &.closed {
-    display: none;
-  }
-
-  &.open {
-    display: block;
-  }
-`;
-
-// Full page-width accordion component which can be linked to on-page
-function Accordion({ expanded = false, id, title, children }) {
-  const hashFragment = window.location.href.split("#")[1];
-  const directlyLinked = Boolean(hashFragment && id && hashFragment === id);
-
-  // The accordion should initially render as opened if explicitly set with
-  // `expanded`, or if it has been directly linked to with a hash parameter.
-  const [open, setOpen] = useState(expanded || directlyLinked);
-
-  function toggleOpen() {
-    setOpen(!open);
-  }
-
-  return (
-    <StyledAccordion id={id}>
-      <AccordionHeader>
-        <button onClick={toggleOpen}>
-          <h3>{title}</h3>
-          {open ? (
-            <Icon id={"ionic-ios-arrow-up.svg"} />
-          ) : (
-            <Icon id={"ionic-ios-arrow-down.svg"} />
-          )}
-        </button>
-      </AccordionHeader>
-      <AccordionBody className={open ? "open" : "closed"}>
-        {children}
-      </AccordionBody>
-    </StyledAccordion>
   );
 }
 

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/data.js
@@ -127,6 +127,7 @@ const content = [
       {
         type: "button-link",
         children: "Register for a Basic BCeID",
+        href: "/under-construction",
         primary: true,
       },
     ],


### PR DESCRIPTION
Accessibility additions to the Accordion component and simpler MoreInfo version:
- `aria-` and `id` attributes added following the example set by the [Accordion example from W3C WAI-ARIA](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion)
- `:focus` and `:hover` styling extended to make sure there are at least two visual signifiers on focus or hover
- `headingLevel` prop added to the Accordion component to allow correct semantic usage of the section heading element (`<h1>` ... `<h6>`) by passing an integer argument; defaults to `<h3>` if not supplied
- `className` prop added to the Accordion component to [pass `styled-components` styling](https://styled-components.com/docs/basics#styling-any-component) when used in another component (ex: TableGroup)
- Logic added to Accordion handling of `children` prop so that it can take an array (handled by `textService.buildHtmlElement()`) or a regular React-style `children` argument for composition in other components (ex: TableGroup)
- Left margin added to MoreInfo on mobile to bring it in line with all other TableGroup cell elements on screen widths up to 575px

Button and link accessibility updates:
- `:focus` styling added for keyboard navigation

TableGroup updates:
- Rather than a simpler copy-pasted Accordion implementation, TableGroup uses the Accordion directly in the "Type" view