### PR TITLE
Add feature flag for Personalization block based on window URL

### DIFF
--- a/react-app/src/pages/Home/index.js
+++ b/react-app/src/pages/Home/index.js
@@ -15,6 +15,14 @@ const Section = styled.section`
 function Home() {
   const [searchTerm, setSearchTerm] = useState("");
 
+  // Feature flag to determine whether to show Personalization block.
+  // Hide the block in production deployment.
+  const FEATURE_SHOW_PERSONALIZATION = window.location.href.includes(
+    "bc-gng-prototype"
+  )
+    ? false
+    : true;
+
   function handleSearchInput(inputValue) {
     setSearchTerm(inputValue);
   }
@@ -22,13 +30,13 @@ function Home() {
   return (
     <>
       {/* Full width block personalization block */}
-      {/* TODO: Un-comment this block out pending future Personalization /
-      Life Events design work. */}
-      {/* <Personalization
-        parentCallback={handleSearchInput}
-        personalization={personalization}
-        searchTerm={searchTerm}
-      /> */}
+      {FEATURE_SHOW_PERSONALIZATION && (
+        <Personalization
+          parentCallback={handleSearchInput}
+          personalization={personalization}
+          searchTerm={searchTerm}
+        />
+      )}
 
       {/* 4 highlight tiles with larger icons */}
       <Highlights highlights={highlights} />


### PR DESCRIPTION
This PR adds a feature flag around the Personalization block on the Homepage within the React front-end.

This flag does a simple check for the string `bc-gng-prototype` in the URL to determine whether we are in the production environment. In production, the Personalization block is hidden, as it is too early in the design phase to be shown to design research participants.