### PR TITLE
CSS Grid fallback for Internet Explorer

### DIFF
--- a/react-app/src/components/ServiceHighlight.js
+++ b/react-app/src/components/ServiceHighlight.js
@@ -17,7 +17,6 @@ const ServiceHighlightDiv = styled.div`
   }
 
   svg {
-    height: 90px;
     margin: 10px 20px 0 10px;
     max-width: 90px;
   }

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -55,25 +55,88 @@ const ServicesContentStyled = styled.div`
   div.div--service-highlight-container {
     display: block;
     margin: 0 0 20px 0;
-  }
-  @media (min-width: 576px) {
-    div.div--service-highlight-container {
+
+    @media (min-width: 576px) {
       max-width: 576px;
     }
-  }
-  @media (min-width: 768px) {
-    div.div--service-highlight-container {
+    @media (min-width: 768px) {
       max-width: 768px;
       display: grid;
       grid-template-columns: repeat(2, 1fr);
       column-gap: 20px;
       row-gap: 20px;
     }
-  }
-  @media (min-width: 992px) {
-    div.div--service-highlight-container {
+    @media (min-width: 992px) {
       max-width: 970px;
       grid-template-columns: repeat(3, 1fr);
+    }
+
+    /* Grid fallback for Internet Explorer 10+ */
+    @media (min-width: 768px) and (-ms-high-contrast: none),
+      (-ms-high-contrast: active) {
+      display: -ms-grid;
+
+      /* With no column- or row-gap support, we must explicitly set the value
+      when defining rows and columns. */
+      -ms-grid-columns: (1fr 20px 1fr);
+      -ms-grid-rows: (1fr 20px 1fr 20px 1fr);
+
+      /* These divs refer to ServiceHighlight divs. Note that even column and
+      row values are avoided because those now refer to our 20px gap. */
+      div:nth-child(1) {
+        -ms-grid-column: 1;
+        -ms-grid-row: 1;
+      }
+      div:nth-child(2) {
+        -ms-grid-column: 3;
+        -ms-grid-row: 1;
+      }
+      div:nth-child(3) {
+        -ms-grid-column: 1;
+        -ms-grid-row: 3;
+      }
+      div:nth-child(4) {
+        -ms-grid-column: 3;
+        -ms-grid-row: 3;
+      }
+      div:nth-child(5) {
+        -ms-grid-column: 1;
+        -ms-grid-row: 5;
+      }
+      div:nth-child(6) {
+        -ms-grid-column: 3;
+        -ms-grid-row: 5;
+      }
+    }
+    @media (min-width: 992px) and (-ms-high-contrast: none),
+      (-ms-high-contrast: active) {
+      -ms-grid-columns: (1fr 20px 1fr 20px 1fr);
+      -ms-grid-rows: (1fr 20px 1fr);
+
+      div:nth-child(1) {
+        -ms-grid-column: 1;
+        -ms-grid-row: 1;
+      }
+      div:nth-child(2) {
+        -ms-grid-column: 3;
+        -ms-grid-row: 1;
+      }
+      div:nth-child(3) {
+        -ms-grid-column: 5;
+        -ms-grid-row: 1;
+      }
+      div:nth-child(4) {
+        -ms-grid-column: 1;
+        -ms-grid-row: 3;
+      }
+      div:nth-child(5) {
+        -ms-grid-column: 3;
+        -ms-grid-row: 3;
+      }
+      div:nth-child(6) {
+        -ms-grid-column: 5;
+        -ms-grid-row: 3;
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds CSS grid fallback code for Internet Explorer on the Services page.

- `(-ms-high-contrast: none), (-ms-high-contrast: active)` is used as a CSS targeting mechanism for IE10+
- `-ms-grid-columns` and `-ms-grid-rows` are used in place of `grid-template-columns` (see [caniuse.com documentation for grid-template-columns](https://caniuse.com/?search=grid-template-columns))
- Since we are using a `row-gap` and `column-gap` and [Internet Explorer doesn't support this feature](https://caniuse.com/mdn-css_properties_row-gap_grid_context), we need to explicitly set our gutters in the row and column definitions
- Because we have the column and row gap, we can't use the [Internet Explorer repeating grid tracks syntax](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/hh673533(v=vs.85)?redirectedfrom=MSDN#repeating-grid-tracks), and we must be explicit about each grid cell
- ~5x as much code to support one browser than to support every other browser 🙃 

Additionally, the explicit height set on the SVG images in the ServiceHighlight component is removed to allow for proper display in IE.