### PR TITLE
More CSS grid fallbacks for Internet Explorer

### DIFF
--- a/react-app/src/components/Navigation.js
+++ b/react-app/src/components/Navigation.js
@@ -30,6 +30,191 @@ const Section = styled.div`
     max-width: 970px;
     grid-template-columns: repeat(3, 1fr);
   }
+
+  /* Grid fallback for Internet Explorer 10+ - assumes 20 or less children */
+  @media (min-width: 768px) and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
+    display: -ms-grid;
+
+    /* With no column- or row-gap support, we must explicitly set the gap value
+    when defining columns. */
+    -ms-grid-columns: 1fr 30px 1fr; // 2 columns with gap
+
+    /* Add a bottom margin to the Card div as a substitute for row-gap, since we
+    don't know how many rows to expect ahead of time. */
+    div {
+      margin-bottom: 24px;
+    }
+
+    /* These divs refer to Card divs. Note that column 2 is avoided because that
+    now refers to our gap column. */
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(5) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(6) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(7) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(8) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(9) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(10) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(11) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(12) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(13) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 7;
+    }
+    div:nth-child(14) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 7;
+    }
+    div:nth-child(15) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 8;
+    }
+    div:nth-child(16) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 8;
+    }
+    div:nth-child(17) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 9;
+    }
+    div:nth-child(18) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 9;
+    }
+    div:nth-child(19) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 10;
+    }
+    div:nth-child(20) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 10;
+    }
+  }
+  @media (min-width: 992px) and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
+    display: -ms-grid;
+    -ms-grid-columns: 1fr 30px 1fr 30px 1fr; // 3 columns with gap
+
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(5) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(6) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(7) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(8) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(9) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(10) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(11) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(12) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(13) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(14) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(15) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(16) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(17) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(18) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(19) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 7;
+    }
+    div:nth-child(20) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 7;
+    }
+  }
 `;
 
 const StyledCard = styled.div`

--- a/react-app/src/pages/Home/Highlights.js
+++ b/react-app/src/pages/Home/Highlights.js
@@ -26,13 +26,13 @@ const HighlightsGrid = styled.div`
   @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
     display: -ms-grid;
 
-    /* With no column- or row-gap support, we must explicitly set the value
+    /* With no column- or row-gap support, we must explicitly set the gap value
     when defining rows and columns. */
-    -ms-grid-columns: 1fr 24px 1fr;
-    -ms-grid-rows: 1fr 24px 1fr;
+    -ms-grid-columns: 1fr 24px 1fr; // 2 columns with gap
+    -ms-grid-rows: 1fr 24px 1fr; // 2 rows with gap
 
     /* These divs refer to HighlightCard divs. Note that even column and
-      row values are avoided because those now refer to our 24px gap. */
+      row values are avoided because those now refer to our gap. */
     div:nth-child(1) {
       -ms-grid-column: 1;
       -ms-grid-row: 1;
@@ -52,8 +52,8 @@ const HighlightsGrid = styled.div`
   }
   @media (min-width: 992px) and (-ms-high-contrast: none),
     (-ms-high-contrast: active) {
-    -ms-grid-columns: 1fr 24px 1fr 24px 1fr 24px 1fr;
-    -ms-grid-rows: auto; // single row
+    -ms-grid-columns: 1fr 24px 1fr 24px 1fr 24px 1fr; // 4 columns with gap
+    -ms-grid-rows: auto; // 1 row
 
     div:nth-child(1) {
       -ms-grid-column: 1;

--- a/react-app/src/pages/Home/Highlights.js
+++ b/react-app/src/pages/Home/Highlights.js
@@ -21,6 +21,57 @@ const HighlightsGrid = styled.div`
     max-width: 1168px;
     grid-template-columns: repeat(4, 1fr);
   }
+
+  /* Grid fallback for Internet Explorer 10+ - assumes 4 children */
+  @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    display: -ms-grid;
+
+    /* With no column- or row-gap support, we must explicitly set the value
+    when defining rows and columns. */
+    -ms-grid-columns: 1fr 24px 1fr;
+    -ms-grid-rows: 1fr 24px 1fr;
+
+    /* These divs refer to HighlightCard divs. Note that even column and
+      row values are avoided because those now refer to our 24px gap. */
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 3;
+    }
+  }
+  @media (min-width: 992px) and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
+    -ms-grid-columns: 1fr 24px 1fr 24px 1fr 24px 1fr;
+    -ms-grid-rows: auto; // single row
+
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 1;
+    }
+  }
 `;
 
 const HighlightCard = styled.div`

--- a/react-app/src/pages/Home/Highlights.js
+++ b/react-app/src/pages/Home/Highlights.js
@@ -100,7 +100,7 @@ const HighlightCard = styled.div`
 
     svg {
       color: #313132;
-      max-height: 125px;
+      height: 125px;
       max-width: 125px;
     }
   }

--- a/react-app/src/pages/Home/Topics.js
+++ b/react-app/src/pages/Home/Topics.js
@@ -26,6 +26,191 @@ const TopicsGrid = styled.div`
     max-width: 1168px;
     grid-template-columns: repeat(4, 1fr);
   }
+
+  /* Grid fallback for Internet Explorer 10+ - assumes 20 or less children */
+  @media (min-width: 768px) and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
+    display: -ms-grid;
+
+    /* With no column- or row-gap support, we must explicitly set the gap value
+    when defining columns. */
+    -ms-grid-columns: 1fr 24px 1fr; // 2 columns with gap
+
+    /* Add a bottom margin to the Card div as a substitute for row-gap, since we
+    don't know how many rows to expect ahead of time. */
+    div {
+      margin-bottom: 16px;
+    }
+
+    /* These divs refer to Card divs. Note that even numbered columns are
+    avoided because those now refer to our gap. */
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(5) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(6) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(7) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(8) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(9) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(10) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(11) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(12) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 6;
+    }
+    div:nth-child(13) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 7;
+    }
+    div:nth-child(14) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 7;
+    }
+    div:nth-child(15) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 8;
+    }
+    div:nth-child(16) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 8;
+    }
+    div:nth-child(17) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 9;
+    }
+    div:nth-child(18) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 9;
+    }
+    div:nth-child(19) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 10;
+    }
+    div:nth-child(20) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 10;
+    }
+  }
+  @media (min-width: 992px) and (-ms-high-contrast: none),
+    (-ms-high-contrast: active) {
+    display: -ms-grid;
+    -ms-grid-columns: 1fr 24px 1fr 24px 1fr 24px 1fr; // 4 columns with gap
+
+    div:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(2) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(3) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(4) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 1;
+    }
+    div:nth-child(5) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(6) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(7) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(8) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 2;
+    }
+    div:nth-child(9) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(10) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(11) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(12) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 3;
+    }
+    div:nth-child(13) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(14) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(15) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(16) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 4;
+    }
+    div:nth-child(17) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(18) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(19) {
+      -ms-grid-column: 5;
+      -ms-grid-row: 5;
+    }
+    div:nth-child(20) {
+      -ms-grid-column: 7;
+      -ms-grid-row: 5;
+    }
+  }
 `;
 
 const TopicsCard = styled.div`

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -76,10 +76,10 @@ const ServicesContentStyled = styled.div`
       (-ms-high-contrast: active) {
       display: -ms-grid;
 
-      /* With no column- or row-gap support, we must explicitly set the value
-      when defining rows and columns. */
-      -ms-grid-columns: 1fr 20px 1fr;
-      -ms-grid-rows: 1fr 20px 1fr 20px 1fr;
+      /* With no column- or row-gap support, we must explicitly set the gap
+      value when defining rows and columns. */
+      -ms-grid-columns: 1fr 20px 1fr; // 2 columns with gap
+      -ms-grid-rows: 1fr 20px 1fr 20px 1fr; // 3 rows with gap
 
       /* These divs refer to ServiceHighlight divs. Note that even column and
       row values are avoided because those now refer to our 20px gap. */
@@ -110,8 +110,8 @@ const ServicesContentStyled = styled.div`
     }
     @media (min-width: 992px) and (-ms-high-contrast: none),
       (-ms-high-contrast: active) {
-      -ms-grid-columns: 1fr 20px 1fr 20px 1fr;
-      -ms-grid-rows: 1fr 20px 1fr;
+      -ms-grid-columns: 1fr 20px 1fr 20px 1fr; // 3 columns with gap
+      -ms-grid-rows: 1fr 20px 1fr; // 2 rows with gap
 
       div:nth-child(1) {
         -ms-grid-column: 1;

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -71,15 +71,15 @@ const ServicesContentStyled = styled.div`
       grid-template-columns: repeat(3, 1fr);
     }
 
-    /* Grid fallback for Internet Explorer 10+ */
+    /* Grid fallback for Internet Explorer 10+ - assumes 6 children */
     @media (min-width: 768px) and (-ms-high-contrast: none),
       (-ms-high-contrast: active) {
       display: -ms-grid;
 
       /* With no column- or row-gap support, we must explicitly set the value
       when defining rows and columns. */
-      -ms-grid-columns: (1fr 20px 1fr);
-      -ms-grid-rows: (1fr 20px 1fr 20px 1fr);
+      -ms-grid-columns: 1fr 20px 1fr;
+      -ms-grid-rows: 1fr 20px 1fr 20px 1fr;
 
       /* These divs refer to ServiceHighlight divs. Note that even column and
       row values are avoided because those now refer to our 20px gap. */
@@ -110,8 +110,8 @@ const ServicesContentStyled = styled.div`
     }
     @media (min-width: 992px) and (-ms-high-contrast: none),
       (-ms-high-contrast: active) {
-      -ms-grid-columns: (1fr 20px 1fr 20px 1fr);
-      -ms-grid-rows: (1fr 20px 1fr);
+      -ms-grid-columns: 1fr 20px 1fr 20px 1fr;
+      -ms-grid-rows: 1fr 20px 1fr;
 
       div:nth-child(1) {
         -ms-grid-column: 1;


### PR DESCRIPTION
This PR adds CSS grid fallback code to the following areas:

- Homepage Highlights (428602c) - ~4x as much IE grid code as code for every other browser
- Homepage Topics (e827f3e) - ~13x as much code
- Navigation component (f4125d8) - ~13x as much code

Additional changes in this PR:
- Extraneous parentheses removed from Services page IE grid implementation (b3fb247)
- Comment clarity improved in Services page and Highlights component (2c2a40c)
- Highlights component SVGs have explicit `height` set for display in IE (abfc6f0)