### PR TITLE
Add height 100% to SVGs in ServiceHighlight for display on iOS

### DIFF
--- a/react-app/src/components/ServiceHighlight.js
+++ b/react-app/src/components/ServiceHighlight.js
@@ -17,6 +17,7 @@ const ServiceHighlightDiv = styled.div`
   }
 
   svg {
+    height: 100%;
     margin: 10px 20px 0 10px;
     max-width: 90px;
   }


### PR DESCRIPTION
The previous explicit `height` of 90px allowed Internet Explorer to display the SVGs as expected, but this broke display in iOS. Setting it to 100% while leaving a `max-width` in place allows for display across browsers.