### PR TITLE
GNG-383: Switch max-width to width for SVG display in Safari

### DIFF
--- a/react-app/src/components/ServiceHighlight.js
+++ b/react-app/src/components/ServiceHighlight.js
@@ -19,7 +19,7 @@ const ServiceHighlightDiv = styled.div`
   svg {
     height: 100%;
     margin: 10px 20px 0 10px;
-    max-width: 90px;
+    width: 90px;
   }
 
   span.span--service-title svg {


### PR DESCRIPTION
This PR fixes SVG display in Safari in the Services page ServiceHighlight component. With `max-width` set explicitly to a pixel value and `height` set to 100%, other browsers will display the SVG but Safari on macOS or iOS won't. In this case, browsers are going to display SVGs at 90px wide because of the container size, so setting 90px explicitly with `width` vs `max-width` works well across browsers.