### PR TITLE
GNG-379: Add font-display: swap for all instances of BC Sans usage

### DIFF
--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -166,6 +166,7 @@ const MoreInfoHeader = styled.div`
     color: #1a5a96;
     cursor: pointer;
     display: block;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     font-weight: 400;

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -11,6 +11,7 @@ const StyledButton = styled.button`
   color: ${(props) => (props.primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
@@ -110,6 +111,7 @@ const StyledLink = styled.a`
   color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
@@ -145,6 +147,7 @@ const StyledRouterLink = styled(Link)`
   color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;

--- a/react-app/src/components/Header/Nav/LanguagePicker.js
+++ b/react-app/src/components/Header/Nav/LanguagePicker.js
@@ -19,6 +19,7 @@ const LanguagePickerStyled = styled.div`
     color: #313132;
     cursor: pointer;
     display: flex;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;
     padding: 0;

--- a/react-app/src/components/Header/Nav/SearchBar.js
+++ b/react-app/src/components/Header/Nav/SearchBar.js
@@ -31,6 +31,7 @@ const SearchForm = styled.div`
     background: none;
     border: 0;
     display: inline-block;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 24px;
     height: 76px;

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -125,6 +125,7 @@ const SearchBar = styled.div`
     background: none;
     border: 0;
     display: inline-block;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 20px;
     padding: 10px 16px;

--- a/react-app/src/components/Header/Nav/UserPanel.js
+++ b/react-app/src/components/Header/Nav/UserPanel.js
@@ -19,6 +19,7 @@ const UserPanelStyled = styled.div`
     color: #313132;
     cursor: pointer;
     display: flex;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;
     padding: 0;

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -12,6 +12,7 @@ import { ReactComponent as HamburgerIcon } from "../../assets/bars-solid.svg";
 const NavStyled = styled.nav`
   background-color: white;
   display: flex;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   height: 80px;

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -26,6 +26,7 @@ const SearchForm = styled.div`
     background: none;
     border: 0;
     display: inline-block;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     padding: 10px;

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -27,6 +27,7 @@ const StyledTable = styled.table`
         border: 0;
         color: #313132;
         cursor: pointer;
+        font-display: swap;
         font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
         font-size: 20px;
         font-weight: 700;

--- a/react-app/src/components/TextInput.js
+++ b/react-app/src/components/TextInput.js
@@ -11,6 +11,7 @@ const StyledTextInput = styled.input`
   border: 2px solid #606060;
   border-radius: 4px;
   display: block;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   height: 34px;

--- a/react-app/src/index.scss
+++ b/react-app/src/index.scss
@@ -13,6 +13,7 @@ html {
 
 body {
   margin: 0;
+  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -25,6 +26,7 @@ body {
 }
 
 code {
+  font-display: swap;
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -99,6 +99,7 @@ const SearchBlock = styled.div`
       border: none;
       border-bottom: 1px solid #313132;
       border-radius: 0;
+      font-display: swap;
       font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
       font-size: 18px;
       padding: 0;

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -29,6 +29,7 @@ const ServicesContentStyled = styled.div`
     border: 0;
     box-sizing: border-box;
     display: inline-block;
+    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 24px;
     height: 44px;


### PR DESCRIPTION
As part of a [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) audit of the app, "flash of invisible text" (FOIT) was detected because of our [BC Sans](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/bc-visual-identity/bc-sans) usage everywhere.

This PR adds `font-display: swap` to direct browsers to use a [very small blocking period and an infinite swap period](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values) when loading fonts. This strategy trades temporarily invisible font display (FOIT) for "flash of unstyled text" (FOUT), which is preferable.