### PR TITLE
Inline BC Sans code for font-swap: display usage

### DIFF
--- a/react-app/src/components/Accordion.js
+++ b/react-app/src/components/Accordion.js
@@ -166,7 +166,6 @@ const MoreInfoHeader = styled.div`
     color: #1a5a96;
     cursor: pointer;
     display: block;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     font-weight: 400;

--- a/react-app/src/components/Button.js
+++ b/react-app/src/components/Button.js
@@ -11,7 +11,6 @@ const StyledButton = styled.button`
   color: ${(props) => (props.primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
@@ -111,7 +110,6 @@ const StyledLink = styled.a`
   color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;
@@ -147,7 +145,6 @@ const StyledRouterLink = styled(Link)`
   color: ${(props) => (props.$primary ? "white" : "#003366")};
   cursor: pointer;
   display: inline-block;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   font-weight: 700;

--- a/react-app/src/components/Header/Nav/LanguagePicker.js
+++ b/react-app/src/components/Header/Nav/LanguagePicker.js
@@ -19,7 +19,6 @@ const LanguagePickerStyled = styled.div`
     color: #313132;
     cursor: pointer;
     display: flex;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;
     padding: 0;

--- a/react-app/src/components/Header/Nav/SearchBar.js
+++ b/react-app/src/components/Header/Nav/SearchBar.js
@@ -31,7 +31,6 @@ const SearchForm = styled.div`
     background: none;
     border: 0;
     display: inline-block;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 24px;
     height: 76px;

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -125,7 +125,6 @@ const SearchBar = styled.div`
     background: none;
     border: 0;
     display: inline-block;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 20px;
     padding: 10px 16px;

--- a/react-app/src/components/Header/Nav/UserPanel.js
+++ b/react-app/src/components/Header/Nav/UserPanel.js
@@ -19,7 +19,6 @@ const UserPanelStyled = styled.div`
     color: #313132;
     cursor: pointer;
     display: flex;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     height: 44px;
     padding: 0;

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -12,7 +12,6 @@ import { ReactComponent as HamburgerIcon } from "../../assets/bars-solid.svg";
 const NavStyled = styled.nav`
   background-color: white;
   display: flex;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   height: 80px;

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -26,7 +26,6 @@ const SearchForm = styled.div`
     background: none;
     border: 0;
     display: inline-block;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     padding: 10px;

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -27,7 +27,6 @@ const StyledTable = styled.table`
         border: 0;
         color: #313132;
         cursor: pointer;
-        font-display: swap;
         font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
         font-size: 20px;
         font-weight: 700;

--- a/react-app/src/components/TextInput.js
+++ b/react-app/src/components/TextInput.js
@@ -11,7 +11,6 @@ const StyledTextInput = styled.input`
   border: 2px solid #606060;
   border-radius: 4px;
   display: block;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
   height: 34px;

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -5,7 +5,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import "./index.scss";
-import "@bcgov/bc-sans/css/BCSans.css";
 import App from "./App";
 import ScrollToTop from "./components/ScrollToTop";
 import * as serviceWorker from "./serviceWorker";

--- a/react-app/src/index.scss
+++ b/react-app/src/index.scss
@@ -32,3 +32,38 @@ code {
 *:focus {
   outline: none;
 }
+
+// Declare our @font-faces here rather than using included @bc-gov/bc-sans .css
+// file so that we can extended the @font-face declarations with font-display.
+@font-face {
+  src: url("../node_modules/@bcgov/bc-sans/fonts/BCSans-Regular.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
+  font-family: "BCSans";
+  font-display: swap;
+}
+@font-face {
+  src: url("../node_modules/@bcgov/bc-sans/fonts/BCSans-BoldItalic.woff")
+    format("woff");
+  font-weight: 700;
+  font-style: italic;
+  font-family: "BCSans";
+  font-display: swap;
+}
+@font-face {
+  src: url("../node_modules/@bcgov/bc-sans/fonts/BCSans-Italic.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: italic;
+  font-family: "BCSans";
+  font-display: swap;
+}
+@font-face {
+  src: url("../node_modules/@bcgov/bc-sans/fonts/BCSans-Bold.woff")
+    format("woff");
+  font-weight: 700;
+  font-style: normal;
+  font-family: "BCSans";
+  font-display: swap;
+}

--- a/react-app/src/index.scss
+++ b/react-app/src/index.scss
@@ -13,7 +13,6 @@ html {
 
 body {
   margin: 0;
-  font-display: swap;
   font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -26,7 +25,6 @@ body {
 }
 
 code {
-  font-display: swap;
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -99,7 +99,6 @@ const SearchBlock = styled.div`
       border: none;
       border-bottom: 1px solid #313132;
       border-radius: 0;
-      font-display: swap;
       font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
       font-size: 18px;
       padding: 0;

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -29,7 +29,6 @@ const ServicesContentStyled = styled.div`
     border: 0;
     box-sizing: border-box;
     display: inline-block;
-    font-display: swap;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 24px;
     height: 44px;


### PR DESCRIPTION
This PR reverses the changes in #101 and instead in-lines the BC Sans `@font-face` declarations so that we can use `font-display: swap`. Unfortunately it is not possible to extend imported `@font-face` declarations installed in `node_modules`, so this copy-paste strategy is necessary.