### PR TITLE
Accessibility-related styling updates

### DIFF
--- a/react-app/src/App.scss
+++ b/react-app/src/App.scss
@@ -6,6 +6,9 @@ main {
     color: #1a5a96;
     text-decoration: underline;
   }
+  a:focus {
+    outline: 4px solid #3b99fc;
+  }
   a:hover {
     text-decoration: none;
     color: blue;

--- a/react-app/src/components/Breadcrumbs.js
+++ b/react-app/src/components/Breadcrumbs.js
@@ -51,6 +51,15 @@ const StyledBreadcrumb = styled.li`
   span {
     color: #313132;
     text-decoration: none;
+
+    :focus {
+      outline: 4px solid #3b99fc;
+      text-decoration: underline;
+    }
+
+    :hover {
+      text-decoration: underline;
+    }
   }
 
   &:first-child {

--- a/react-app/src/components/Header/Alert/index.js
+++ b/react-app/src/components/Header/Alert/index.js
@@ -63,6 +63,15 @@ const StyledAlert = styled.div`
 
       a {
         color: white;
+
+        :focus {
+          outline: 4px solid #3b99fc;
+          text-decoration: none;
+        }
+
+        :hover {
+          text-decoration: none;
+        }
       }
     }
   }
@@ -77,6 +86,15 @@ const StyledAlert = styled.div`
 
     svg {
       color: white;
+    }
+
+    :focus {
+      background-color: #5f9cd8;
+      outline: 4px solid #3b99fc;
+    }
+
+    :hover {
+      background-color: #5f9cd8;
     }
   }
 

--- a/react-app/src/components/Header/Nav/SearchBar.js
+++ b/react-app/src/components/Header/Nav/SearchBar.js
@@ -38,6 +38,10 @@ const SearchForm = styled.div`
     vertical-align: middle;
     max-width: 872px;
     width: 872px;
+
+    :focus {
+      outline: 4px solid #3b99fc;
+    }
   }
 `;
 

--- a/react-app/src/components/Header/Nav/SearchButton.js
+++ b/react-app/src/components/Header/Nav/SearchButton.js
@@ -14,11 +14,16 @@ const SearchButtonStyled = styled.div`
   button.button--search {
     background: none;
     border: 0;
+    cursor: pointer;
     display: inline-block;
     height: 44px;
     margin: 16px 20px;
     padding: 0;
     width: 44px;
+
+    :focus {
+      outline: 4px solid #3b99fc;
+    }
   }
 
   button.button--search svg {
@@ -28,17 +33,28 @@ const SearchButtonStyled = styled.div`
 
   // SearchButton in Nav menu is a special case
   &.div--search-button-nav {
-    background-color: #f2f2f2;
-    height: 80px;
-    width: 70px;
-
     button.button--search {
-      margin: 18px 19px 18px 13px;
+      background-color: #f2f2f2;
+      height: 80px;
+      margin: 0;
+      width: 80px;
+
+      :focus {
+        background-color: #dedede;
+      }
+
+      :hover {
+        background-color: #dedede;
+      }
     }
 
     button.button--search svg {
       color: #313132;
-      margin: 11px;
+      height: 25px;
+    }
+
+    :hover {
+      background-color: #ededed;
     }
   }
 `;

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -59,6 +59,10 @@ const Menu = styled.div`
         padding: 10px 16px;
         width: 320px;
 
+        :focus {
+          outline: 4px solid #3b99fc;
+        }
+
         &.slide-out-menu-li-navlink {
           font-weight: 700;
           padding: 0;
@@ -130,6 +134,10 @@ const SearchBar = styled.div`
     padding: 10px 16px;
     vertical-align: middle;
     width: 276px;
+
+    :focus {
+      outline: 4px solid #3b99fc;
+    }
   }
 `;
 
@@ -137,6 +145,7 @@ const SearchButton = styled.button`
   background: none;
   border: none;
   box-sizing: border-box;
+  cursor: pointer;
   display: inline-block;
   height: 44px;
   overflow: hidden;
@@ -145,6 +154,15 @@ const SearchButton = styled.button`
 
   svg {
     color: #888888;
+  }
+
+  :focus {
+    background-color: #dedede;
+    outline: 4px solid #3b99fc;
+  }
+
+  :hover {
+    background-color: #dedede;
   }
 `;
 

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -55,6 +55,15 @@ const NavStyled = styled.nav`
       line-height: 50px;
       margin-bottom: 15px;
     }
+
+    :focus {
+      outline: 4px solid #3b99fc;
+      text-decoration: underline;
+    }
+
+    :hover {
+      text-decoration: underline;
+    }
   }
 
   ul li a.a--current-page {

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -93,6 +93,16 @@ const NavStyled = styled.nav`
     padding: 20px 14px 8px 14px;
     text-align: center;
     width: 80px;
+
+    :focus {
+      background-color: #dedede;
+      outline: 4px solid #3b99fc;
+    }
+
+    :hover {
+      background-color: #dedede;
+      text-decoration: underline;
+    }
   }
   button.button--menu-button > svg {
     height: 24px;

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -85,7 +85,7 @@ const NavStyled = styled.nav`
     background-color: #f2f2f2;
     border: 0;
     box-sizing: border-box;
-    color: #888888;
+    color: #313132;
     cursor: pointer;
     display: flex;
     flex-direction: column;

--- a/react-app/src/components/Header/index.js
+++ b/react-app/src/components/Header/index.js
@@ -57,6 +57,10 @@ const HeaderStyled = styled.header`
     }
   }
 
+  div.wrapper > div.div--title > a:focus {
+    outline: 4px solid #3b99fc;
+  }
+
   div.wrapper > div.div--title > a > svg.logo {
     display: inline-block;
     height: 80px;

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -28,6 +28,9 @@ const StyledSkipLink = styled.a`
   display: hidden;
   font-weight: 700;
   width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 2;
 
   div {
     display: none;

--- a/react-app/src/components/Page.js
+++ b/react-app/src/components/Page.js
@@ -79,6 +79,10 @@ const StyledBackArrow = styled(Link)`
     top: 2px;
     z-index: -1;
   }
+
+  :focus {
+    color: blue;
+  }
 `;
 
 function BackArrow({ href, ariaLabel }) {

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -31,6 +31,10 @@ const SearchForm = styled.div`
     padding: 10px;
     vertical-align: middle;
     width: 872px;
+
+    :focus {
+      outline: 4px solid #3b99fc;
+    }
   }
 `;
 

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -394,26 +394,46 @@ const StyledRadioFilterGroup = styled.form`
         }
 
         input[type="radio"] {
-          display: none;
+          cursor: pointer;
+          height: 0px;
+          opacity: 0;
+          position: absolute;
+          width: 0px;
+
+          :focus {
+            + label {
+              outline: 4px solid #3b99fc;
+            }
+            :checked + label {
+              outline: 4px solid #3b99fc;
+            }
+          }
         }
 
         input[type="radio"] ~ label {
           align-items: center;
-          border: 1px solid transparent;
-          border-radius: 10px;
+          border-radius: 9px;
           cursor: pointer;
           display: flex;
           font-size: 18px;
           justify-content: space-around;
           min-height: 44px;
           text-align: center;
+
+          :hover {
+            background-color: #f2f2f2;
+            text-decoration: underline;
+          }
         }
 
         input[type="radio"]:checked ~ label {
-          border-color: #313132;
           background-color: #313132;
           color: white;
           font-weight: 700;
+
+          :hover {
+            background-color: black;
+          }
         }
       }
     }

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -34,7 +34,12 @@ const StyledTable = styled.table`
         margin: 0 0 8px 0;
         padding: 0;
 
-        &:hover {
+        :focus {
+          outline: 4px solid #3b99fc;
+          text-decoration: underline;
+        }
+
+        :hover {
           color: blue;
           text-decoration: underline;
         }
@@ -45,7 +50,11 @@ const StyledTable = styled.table`
           text-decoration-thickness: 1px;
           text-underline-offset: 2px;
 
-          &:hover {
+          :focus {
+            text-decoration: none;
+          }
+
+          :hover {
             color: blue;
             text-decoration: none;
           }


### PR DESCRIPTION
This PR adds styling updates across many components to add `:focus` and `:hover` styles for keyboard navigation. It also corrects the TableGroup component's radio button `display` styling to allow for keyboard navigation.

- TableGroup
  - Focus and hover style on table heading buttons
  - RadioFilterGroup `<input>` elements are set to `opacity: 0` instead of `display: none` to allow for keyboard navigation
- Breadcrumbs - focus and hover style on links
- SearchBar - focus style
- Skip-to-Main-Content link - positioning fixed to place it at the top of the page
- PageTitle - focus style
- Header
  - Logo link focus style
  - Nav link focus and hover style
  - Nav SVGs are darkened for better contrast
  - Nav button focus and hover style
  - SlideOutMenu link and button focus and hover style
  - SearchBar focus style
  - SearchButton focus, hover, cursor style
  - Alert button and link focus and hover style
- App-wide link focus style added in the App component's SCSS