### PR TITLE
Page titles and meta descriptions using react-helmet

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -10,27 +10,28 @@
       "dependencies": {
         "@bcgov/bc-sans": "1.0.1",
         "core-js": "3.9.1",
-        "dompurify": "2.2.6",
+        "dompurify": "2.2.7",
         "node-sass": "5.0.0",
-        "react": "17.0.1",
+        "react": "17.0.2",
         "react-app-polyfill": "2.0.0",
-        "react-dom": "17.0.1",
+        "react-dom": "17.0.2",
+        "react-helmet": "^6.1.0",
         "react-highlight-words": "0.17.0",
         "react-responsive": "8.2.0",
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
-        "react-tooltip": "4.2.15",
+        "react-tooltip": "4.2.17",
         "styled-components": "5.2.1"
       },
       "devDependencies": {
         "@babel/core": "7.13.10",
-        "@testing-library/jest-dom": "5.11.9",
+        "@testing-library/jest-dom": "5.11.10",
         "@testing-library/react": "11.2.5",
-        "@testing-library/user-event": "12.8.3",
+        "@testing-library/user-event": "13.0.16",
         "husky": "4.3.8",
         "lint-staged": "10.5.4",
         "prettier": "2.2.1",
-        "react-is": "17.0.1"
+        "react-is": "17.0.2"
       },
       "engines": {
         "node": "14.16.0",
@@ -2858,9 +2859,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.11.9",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
-      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "version": "5.11.10",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz",
+      "integrity": "sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2",
@@ -2963,9 +2964,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "version": "13.0.16",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.0.16.tgz",
+      "integrity": "sha512-plXL8lGR2H0xm0fHE0Dfz37ke2UtBI1wAmaWIo6BP7+pGt+BxdBQrITHAMGcac0a3PtBi5CXNPth8S53ISO1Ew==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -7033,9 +7034,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
-      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "node_modules/domutils": {
       "version": "1.7.0",
@@ -17451,9 +17452,9 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -17636,22 +17637,41 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/react-highlight-words": {
       "version": "0.17.0",
@@ -17667,9 +17687,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-      "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-refresh": {
       "version": "0.8.3",
@@ -17960,10 +17980,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-tooltip": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.15.tgz",
-      "integrity": "sha512-xmVWi6N1qsrACiAquv28jhQ10igFbQX0Xk5rjSjgUPi9BAf8lCFhYpdFXe6NrEeuPrM7hdZkePa3eS2SrIRxIw==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.17.tgz",
+      "integrity": "sha512-LzwUbQYzeRyrjbuuCbYUB0dlJpFPGPwigWS052umr1QulcF5N4czabDiWJ+Y585Q7ijvMFuBbeOvnI/azoTusw==",
       "dependencies": {
         "prop-types": "^15.7.2",
         "uuid": "^7.0.3"
@@ -19344,9 +19372,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -25866,9 +25894,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.11.9",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
-      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "version": "5.11.10",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz",
+      "integrity": "sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -25943,9 +25971,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+      "version": "13.0.16",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.0.16.tgz",
+      "integrity": "sha512-plXL8lGR2H0xm0fHE0Dfz37ke2UtBI1wAmaWIo6BP7+pGt+BxdBQrITHAMGcac0a3PtBi5CXNPth8S53ISO1Ew==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
@@ -29220,9 +29248,9 @@
       }
     },
     "dompurify": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
-      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
     },
     "domutils": {
       "version": "1.7.0",
@@ -37152,9 +37180,9 @@
       }
     },
     "react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37290,19 +37318,35 @@
       }
     },
     "react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
     },
     "react-highlight-words": {
       "version": "0.17.0",
@@ -37315,9 +37359,9 @@
       }
     },
     "react-is": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-      "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -37517,10 +37561,16 @@
         }
       }
     },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
+    },
     "react-tooltip": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.15.tgz",
-      "integrity": "sha512-xmVWi6N1qsrACiAquv28jhQ10igFbQX0Xk5rjSjgUPi9BAf8lCFhYpdFXe6NrEeuPrM7hdZkePa3eS2SrIRxIw==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.17.tgz",
+      "integrity": "sha512-LzwUbQYzeRyrjbuuCbYUB0dlJpFPGPwigWS052umr1QulcF5N4czabDiWJ+Y585Q7ijvMFuBbeOvnI/azoTusw==",
       "requires": {
         "prop-types": "^15.7.2",
         "uuid": "^7.0.3"
@@ -38593,9 +38643,9 @@
       }
     },
     "scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -5,27 +5,27 @@
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",
     "core-js": "3.9.1",
-    "dompurify": "2.2.6",
+    "dompurify": "2.2.7",
     "node-sass": "5.0.0",
-    "react": "17.0.1",
+    "react": "17.0.2",
     "react-app-polyfill": "2.0.0",
-    "react-dom": "17.0.1",
+    "react-dom": "17.0.2",
     "react-highlight-words": "0.17.0",
     "react-responsive": "8.2.0",
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
-    "react-tooltip": "4.2.15",
+    "react-tooltip": "4.2.17",
     "styled-components": "5.2.1"
   },
   "devDependencies": {
     "@babel/core": "7.13.10",
-    "@testing-library/jest-dom": "5.11.9",
+    "@testing-library/jest-dom": "5.11.10",
     "@testing-library/react": "11.2.5",
-    "@testing-library/user-event": "12.8.3",
+    "@testing-library/user-event": "13.0.16",
     "husky": "4.3.8",
     "lint-staged": "10.5.4",
     "prettier": "2.2.1",
-    "react-is": "17.0.1"
+    "react-is": "17.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -10,6 +10,7 @@
     "react": "17.0.2",
     "react-app-polyfill": "2.0.0",
     "react-dom": "17.0.2",
+    "react-helmet": "^6.1.0",
     "react-highlight-words": "0.17.0",
     "react-responsive": "8.2.0",
     "react-router-dom": "5.2.0",

--- a/react-app/public/index.html
+++ b/react-app/public/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!--
+      Meta tags defined below get replaced by react-helmet when the attribute
+      `data-react-helmet` is set to `true`.
+    -->
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="robots" content="noindex">
@@ -9,6 +13,7 @@
     <meta
       name="description"
       content="Prototype BC Gov Next Gen site"
+      data-react-helmet="true"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -25,6 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- Title tag default is overwritten by react-helmet -->
     <title>Province of British Columbia</title>
   </head>
   <body>

--- a/react-app/src/PrivateRoute.js
+++ b/react-app/src/PrivateRoute.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import { Route, Redirect } from "react-router-dom";
 
 import Page from "./components/Page";
@@ -7,12 +8,21 @@ function PrivateRoute({
   title,
   breadcrumbs,
   content,
+  metadata,
   parentHref,
   parentTitle,
   ...rest
 }) {
   return localStorage.getItem("user") ? (
     <Route {...rest}>
+      {/* By defining the Helmet defaults here, we can keep the BC branding out
+      of the public Login route. In the future, this can live in App.js */}
+      <Helmet
+        defaultTitle="Province of British Columbia"
+        titleTemplate="%s - Province of British Columbia"
+      >
+        <meta name="description" content="Prototype BC Gov Next Gen site" />
+      </Helmet>
       <Page
         title={title}
         breadcrumbs={breadcrumbs}

--- a/react-app/src/components/Content.js
+++ b/react-app/src/components/Content.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styled from "styled-components";
 
 import { textService } from "../_services/text.service";
@@ -45,13 +46,23 @@ const StyledContent = styled.div`
   }
 `;
 
-function Content({ content }) {
+function Content({ content, metadata }) {
   return (
-    <StyledContent>
-      {content.map((object, index) => {
-        return textService.buildHtmlElement(object, index);
-      })}
-    </StyledContent>
+    <>
+      {metadata && (
+        <Helmet>
+          {metadata?.title && <title>{metadata.title}</title>}
+          {metadata?.description && (
+            <meta name={"description"} content={metadata.description} />
+          )}
+        </Helmet>
+      )}
+      <StyledContent>
+        {content.map((object, index) => {
+          return textService.buildHtmlElement(object, index);
+        })}
+      </StyledContent>
+    </>
   );
 }
 

--- a/react-app/src/pages/Home/index.js
+++ b/react-app/src/pages/Home/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 import styled from "styled-components";
 
 import Personalization from "./Personalization";
@@ -29,6 +30,15 @@ function Home() {
 
   return (
     <>
+      {/* Meta information */}
+      <Helmet>
+        <title>Home</title>
+        <meta
+          name="description"
+          content="Prototype website for the Government of British Columbia"
+        />
+      </Helmet>
+
       {/* Full width block personalization block */}
       {FEATURE_SHOW_PERSONALIZATION && (
         <Personalization

--- a/react-app/src/pages/Login/index.js
+++ b/react-app/src/pages/Login/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import propTypes from "prop-types";
+import { Helmet } from "react-helmet";
 import { Redirect } from "react-router-dom";
 import styled from "styled-components";
 
@@ -44,6 +45,12 @@ function Login(props) {
 
   return (
     <StyledMain>
+      {/* Meta information */}
+      <Helmet>
+        <title>Login</title>
+        <meta name="description" content="Login to prototype" />
+      </Helmet>
+
       <h1>Login</h1>
       <form
         id="form--login"

--- a/react-app/src/pages/Logout/index.js
+++ b/react-app/src/pages/Logout/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 import propTypes from "prop-types";
 import styled from "styled-components";
 
@@ -28,6 +29,12 @@ function Login(props) {
 
   return (
     <StyledMain>
+      {/* Meta information */}
+      <Helmet>
+        <title>Logout</title>
+        <meta name="description" content="Logout of prototype" />
+      </Helmet>
+
       <h1>Logout</h1>
       <form
         id="form--login"

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Helmet } from "react-helmet";
 import propTypes from "prop-types";
 import styled from "styled-components";
 
@@ -167,6 +168,15 @@ function ServicesContent() {
 
   return (
     <ServicesContentStyled>
+      {/* Meta information */}
+      <Helmet>
+        <title>Services</title>
+        <meta
+          name="description"
+          content="B.C. Government search facility for services for its citizens."
+        />
+      </Helmet>
+
       {/* Search bar */}
       <div className="div--search">
         <h2>Find a program or service</h2>

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/After-You-Order/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/After-You-Order/data.js
@@ -326,4 +326,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "After You Order",
+  description:
+    "What happens after you order your student transcript or certificate",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/After-You-Order/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/After-You-Order/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function AfterYouOrder() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default AfterYouOrder;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Before-You-Start/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Before-You-Start/data.js
@@ -427,4 +427,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Before You Start",
+  description:
+    "What you need prior to ordering your student transcript or certificate",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Before-You-Start/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Before-You-Start/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function BeforeYouStart() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default BeforeYouStart;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/data.js
@@ -421,4 +421,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Costs",
+  description:
+    "Costs involved with ordering your student transcript or certificate",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Costs/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function Costs() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default Costs;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/data.js
@@ -477,4 +477,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Eligibility",
+  description:
+    "Find out if you are eligible to order a student transcript or certificate",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/Eligibility/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function Eligibility() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default Eligibility;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/data.js
@@ -671,4 +671,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "How to Order",
+  description: "How to order a student transcript or certificate",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/How-to-Order/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HowToOrder() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HowToOrder;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/data.js
@@ -353,4 +353,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Order Your Student Transcripts",
+  description:
+    "Order a high school transcript or certificate as a current student",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/Order-Your-Student-Transcripts/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function OrderYourStudentTranscripts() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default OrderYourStudentTranscripts;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/data.js
@@ -535,4 +535,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Transcripts and Certificates",
+  description: "Information about B.C. student transcripts and certificates.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/Transcripts-and-Certificates/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TranscriptsAndCertificates() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TranscriptsAndCertificates;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/data.js
@@ -361,4 +361,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Support",
+  description:
+    "Educational support for Kindergarten to Grade 12 students in B.C.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/Support/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/Support/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
-function KindergartenToGrade12() {
-  return <Content content={content} />;
+function Support() {
+  return <Content content={content} metadata={metadata} />;
 }
 
-export default KindergartenToGrade12;
+export default Support;

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/data.js
@@ -90,4 +90,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Kindergarten to Grade 12",
+  description:
+    "Information about Kindergarten to Grade 12 programs and services in B.C.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/K-12/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/K-12/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function KindergartenToGrade12() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default KindergartenToGrade12;

--- a/react-app/src/pages/Themes/Education-and-Training/data.js
+++ b/react-app/src/pages/Themes/Education-and-Training/data.js
@@ -248,4 +248,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Education and Training",
+  description: "Theme page for Education and Training",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Education-and-Training/index.js
+++ b/react-app/src/pages/Themes/Education-and-Training/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EducationAndTraining() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EducationAndTraining;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/data.js
@@ -133,4 +133,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Appendices",
+  description: "Appendices to the Employment Standards Act and Regulations",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/Appendices/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EmploymentStandardsAppendices() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EmploymentStandardsAppendices;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/data.js
@@ -290,4 +290,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Guide to the Employment Standards Act",
+  description:
+    "Information to help workers and employers interpret the legislation found in the B.C. Employment Standards Act and Regulation.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/Guide-to-the-Employment-Standards-Act/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function GuideToTheEmploymentStandardsAct() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default GuideToTheEmploymentStandardsAct;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
@@ -61,4 +61,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Forms and Resources",
+  description:
+    "Printed materials and forms related to employment standards in B.C.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/data.js
@@ -1,59 +1,64 @@
-const sections = [
+const content = [
   {
-    title: "Our Services",
-    cards: [
+    type: "navigation",
+    children: [
       {
-        title: "Guide to the Employment Standards Act",
-        cardLink: {
-          href:
-            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act",
-          external: false,
-        },
-      },
-      {
-        title: "Education and Seminars",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Due Diligence Searches",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Forms",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Facts",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Solutions Explorer",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Working in B.C. Posters",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
+        title: "Our Services",
+        cards: [
+          {
+            title: "Guide to the Employment Standards Act",
+            cardLink: {
+              href:
+                "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards/forms-and-resources/guide-to-the-employment-standards-act",
+              external: false,
+            },
+          },
+          {
+            title: "Education and Seminars",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Due Diligence Searches",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Forms",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Facts",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Solutions Explorer",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Working in B.C. Posters",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+        ],
       },
     ],
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../../../../components/Content";
+import { content } from "./data";
 
 function FormsAndResources() {
-  return <Navigation sections={sections} />;
+  return <Content content={content} />;
 }
 
 export default FormsAndResources;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Forms-and-Resources/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function FormsAndResources() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default FormsAndResources;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/data.js
@@ -223,4 +223,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Hiring Domestic Workers",
+  description:
+    "Information about the requirements for employing domestic workers in B.C.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Domestic-Workers/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HiringEmployees() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HiringEmployees;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/How-to-Apply/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/How-to-Apply/data.js
@@ -325,4 +325,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "How to Apply",
+  description: "How to apply for a recruiter's license in British Columbia",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/How-to-Apply/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/How-to-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HowToApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HowToApply;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/Once-You-Get-Your-License/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/Once-You-Get-Your-License/data.js
@@ -482,4 +482,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Once You Get Your License",
+  description: "Responsibilities after getting your recruiter's license",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/Once-You-Get-Your-License/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/Once-You-Get-Your-License/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function OnceYouGetYourLicense() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default OnceYouGetYourLicense;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/data.js
@@ -666,4 +666,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Apply for a Recruiter's License",
+  description: "Recruiters must be licensed with the provincial government.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/Apply-for-Recruiters-License/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function ApplyForRecruitersLicense() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default ApplyForRecruitersLicense;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/data.js
@@ -90,4 +90,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Hiring Temporary Foreign Workers",
+  description:
+    "If you want to hire or recruit a foreign worker in B.C., you must register or be licensed with the provincial government.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Temporary-Foreign-Workers/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HiringTemporaryForeignWorkers() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HiringTemporaryForeignWorkers;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/Entertainment-Industry/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/Entertainment-Industry/data.js
@@ -649,4 +649,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Entertainment Industry",
+  description:
+    "Regulations for employing young people in the entertainment industry.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/Entertainment-Industry/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/Entertainment-Industry/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EntertainmentIndustry() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EntertainmentIndustry;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/data.js
@@ -1274,4 +1274,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Hiring Young People",
+  description:
+    "The Employment Standards Branch administers the Employment Standards Act and Regulation, which set minimum standards of wages and working conditions for youth.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/Hiring-Young-People/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HiringYoungPeople() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HiringYoungPeople;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/data.js
@@ -403,4 +403,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Hiring Employees",
+  description:
+    "Employers can decide how they would like to advertise a job and hire employees. Employers must be fair in their selection process.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/Hiring-Employees/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HiringEmployees() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HiringEmployees;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/data.js
@@ -557,4 +557,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Employment Standards & Workplace Safety",
+  description: "Links to the various worker protection and safety agencies.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/Employment-Standards/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EmploymentStandards() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EmploymentStandards;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
@@ -1,95 +1,101 @@
-const sections = [
+const content = [
   {
-    cards: [
+    type: "navigation",
+    children: [
       {
-        title: "Employment Standards",
-        description: "Find the Employment Standards or seek help or advice",
-        cardLink: {
-          href:
-            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
-          external: false,
-        },
-      },
-      {
-        title: "Personal Injury & Workplace Safety",
-        description: "Get help with disagreements with WorkSafeBC decisions",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Employment Standards Act",
-        description: "Read the full Employment Standards Act",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Employment Standards Tribunal",
-        description:
-          "Appeal decisions made with regards to the Employment Standards Act",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "WorkSafeBC",
-        description:
-          "Did you suffer from a work-related injury or disease? We can help with return-to-work rehabilitation, compensation, health care benefits and other services.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "The BC Labour Relations Board",
-        description:
-          "Mediates and adjudicates employment and labour relations matters related to unionized workplaces",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Workers’ Compensation Appeal Tribunal",
-        description:
-          "Appeal decisions made by WorkSafeBC on compensation, rehabilitation and occupational health and safety",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Employers’ Advisers Office",
-        description: "Get help and advice regarding workplace safety",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "B.C. Human Rights Tribunal",
-        description:
-          "Read the Human Rights Code, file a human rights complaint, or search for a decision.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Contact the Employment Standards Branch",
-        description:
-          "Contact the Employment Standards Branch for via phone, text, email our visit the offices.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
+        cards: [
+          {
+            title: "Employment Standards",
+            description: "Find the Employment Standards or seek help or advice",
+            cardLink: {
+              href:
+                "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety/employment-standards",
+              external: false,
+            },
+          },
+          {
+            title: "Personal Injury & Workplace Safety",
+            description:
+              "Get help with disagreements with WorkSafeBC decisions",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Employment Standards Act",
+            description: "Read the full Employment Standards Act",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Employment Standards Tribunal",
+            description:
+              "Appeal decisions made with regards to the Employment Standards Act",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "WorkSafeBC",
+            description:
+              "Did you suffer from a work-related injury or disease? We can help with return-to-work rehabilitation, compensation, health care benefits and other services.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "The BC Labour Relations Board",
+            description:
+              "Mediates and adjudicates employment and labour relations matters related to unionized workplaces",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Workers’ Compensation Appeal Tribunal",
+            description:
+              "Appeal decisions made by WorkSafeBC on compensation, rehabilitation and occupational health and safety",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Employers’ Advisers Office",
+            description: "Get help and advice regarding workplace safety",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "B.C. Human Rights Tribunal",
+            description:
+              "Read the Human Rights Code, file a human rights complaint, or search for a decision.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Contact the Employment Standards Branch",
+            description:
+              "Contact the Employment Standards Branch for via phone, text, email our visit the offices.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+        ],
       },
     ],
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/data.js
@@ -98,4 +98,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Employment Standards & Workplace Safety",
+  description: "Links to the various worker protection and safety agencies.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EmploymentStandardsAndWorkplaceSafety() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EmploymentStandardsAndWorkplaceSafety;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/Employment-Standards-and-Workplace-Safety/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../../components/Content";
+import { content } from "./data";
 
 function EmploymentStandardsAndWorkplaceSafety() {
-  return <Navigation sections={sections} />;
+  return <Content content={content} />;
 }
 
 export default EmploymentStandardsAndWorkplaceSafety;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
@@ -165,4 +165,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Employment, Business, and Economic Development",
+  description: "Theme page for Employment, Business and Economic Development",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/data.js
@@ -1,155 +1,163 @@
-const sections = [
+const content = [
   {
-    cards: [
+    type: "navigation",
+    search: {
+      label: "Employment, Business & Economic Development",
+    },
+    children: [
       {
-        title: "Job Seekers & Employees",
-        description:
-          "Access different tools to help find a job or work-related advice.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
+        cards: [
           {
-            href: "/under-construction",
-            label: "WorkBC Job Board",
+            title: "Job Seekers & Employees",
+            description:
+              "Access different tools to help find a job or work-related advice.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "WorkBC Job Board",
+              },
+              {
+                href: "/under-construction",
+                label: "Current B.C. Government Job Postings",
+              },
+              {
+                href: "/under-construction",
+                label: "Know your rights in the workplace",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Current B.C. Government Job Postings",
+            title: "Business",
+            description: "Growing or starting a business? We can help.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "COVID-19 supports for business",
+              },
+              {
+                href: "/under-construction",
+                label: "Liquor regulation licensing",
+              },
+              {
+                href: "/under-construction",
+                label: "BC Companies",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Know your rights in the workplace",
-          },
-        ],
-      },
-      {
-        title: "Business",
-        description: "Growing or starting a business? We can help.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "COVID-19 supports for business",
-          },
-          {
-            href: "/under-construction",
-            label: "Liquor regulation licensing",
+            title: "Employment Standards & Workplace Safety",
+            cardLink: {
+              href:
+                "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety",
+              external: false,
+            },
+            description:
+              "Read the Employment Standards or get help with disagreements with WorkSafeBC decisions.",
+            links: [
+              {
+                href: "/under-construction",
+                label: "Extend a temporary layoff variance",
+              },
+              {
+                href: "/under-construction",
+                label: "File a complaint with WorkSafeBC",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "BC Companies",
-          },
-        ],
-      },
-      {
-        title: "Employment Standards & Workplace Safety",
-        cardLink: {
-          href:
-            "/themes/employment-business-and-economic-development/employment-standards-and-workplace-safety",
-          external: false,
-        },
-        description:
-          "Read the Employment Standards or get help with disagreements with WorkSafeBC decisions.",
-        links: [
-          {
-            href: "/under-construction",
-            label: "Extend a temporary layoff variance",
+            title: "Employers",
+            description: "Find information you need about managing employees.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "COVID-19 supports for business",
+              },
+              {
+                href: "/under-construction",
+                label: "Liquor regulation licensing BC Companies",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "File a complaint with WorkSafeBC",
-          },
-        ],
-      },
-      {
-        title: "Employers",
-        description: "Find information you need about managing employees.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "COVID-19 supports for business",
-          },
-          {
-            href: "/under-construction",
-            label: "Liquor regulation licensing BC Companies",
-          },
-        ],
-      },
-      {
-        title: "Economic Development",
-        description:
-          "Find funding, tools, resources, advice & services to help build your community.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "WorkBC Job Board",
+            title: "Economic Development",
+            description:
+              "Find funding, tools, resources, advice & services to help build your community.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "WorkBC Job Board",
+              },
+              {
+                href: "/under-construction",
+                label: "Current B.C. Government Job Postings",
+              },
+              {
+                href: "/under-construction",
+                label: "Know your rights in the workplace",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Current B.C. Government Job Postings",
+            title: "International Investment & Trade",
+            description:
+              "Find ways to promote British Columbia in trade and business.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Extend a temporary layoff variance",
+              },
+              {
+                href: "/under-construction",
+                label: "File a complaint with WorkSafeBC",
+              },
+              {
+                href: "/under-construction",
+                label: "List of Statutory Holidays",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Know your rights in the workplace",
-          },
-        ],
-      },
-      {
-        title: "International Investment & Trade",
-        description:
-          "Find ways to promote British Columbia in trade and business.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Extend a temporary layoff variance",
-          },
-          {
-            href: "/under-construction",
-            label: "File a complaint with WorkSafeBC",
-          },
-          {
-            href: "/under-construction",
-            label: "List of Statutory Holidays",
-          },
-        ],
-      },
-      {
-        title: "Investment Capital",
-        description:
-          "Find programs to help your business gain access to capital.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Extend a temporary layoff variance",
-          },
-          {
-            href: "/under-construction",
-            label: "File a complaint with WorkSafeBC",
-          },
-          {
-            href: "/under-construction",
-            label: "List of Statutory Holidays",
+            title: "Investment Capital",
+            description:
+              "Find programs to help your business gain access to capital.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Extend a temporary layoff variance",
+              },
+              {
+                href: "/under-construction",
+                label: "File a complaint with WorkSafeBC",
+              },
+              {
+                href: "/under-construction",
+                label: "List of Statutory Holidays",
+              },
+            ],
           },
         ],
       },
@@ -157,4 +165,4 @@ const sections = [
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function EmploymentBusinessAndEconomicDevelopment() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default EmploymentBusinessAndEconomicDevelopment;

--- a/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
+++ b/react-app/src/pages/Themes/Employment-Business-and-Economic-Development/index.js
@@ -1,15 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../components/Content";
+import { content } from "./data";
 
 function EmploymentBusinessAndEconomicDevelopment() {
-  return (
-    <Navigation
-      search={{ label: "Employment, Business & Economic Development" }}
-      sections={sections}
-    />
-  );
+  return <Content content={content} />;
 }
 
 export default EmploymentBusinessAndEconomicDevelopment;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/After-You-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/After-You-Apply/data.js
@@ -542,4 +542,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "After You Apply",
+  description:
+    "Next steps after applying for a dispute resolution through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/After-You-Apply/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/After-You-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function AfterYouApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default AfterYouApply;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/data.js
@@ -590,4 +590,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Before You Apply",
+  description:
+    "Information to know before applying for a dispute resolution through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/Before-You-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function BeforeYouApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default BeforeYouApply;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Apply/data.js
@@ -317,4 +317,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "How to Apply",
+  description:
+    "How to apply for a dispute resolution through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Apply/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HowToApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HowToApply;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/data.js
@@ -557,4 +557,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "How to Pay",
+  description:
+    "How to pay for a dispute resolution through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/How-to-Pay/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HowToPay() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HowToPay;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/data.js
@@ -368,4 +368,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Online Dispute Resolution Applications",
+  description:
+    "Apply for a dispute resolution online through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Online-Dispute-Resolution-Application/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function OnlineDisputeResolutionApplication() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default OnlineDisputeResolutionApplication;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/data.js
@@ -466,4 +466,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Application Fee",
+  description:
+    "Application fee information for a Tenant's Direct Request application.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Application-Fee/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TenantDirectRequestApplicationFee() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TenantDirectRequestApplicationFee;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/data.js
@@ -449,4 +449,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Before You Apply",
+  description:
+    "Information to know before you apply for a Tenant's Direct Request application.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Before-You-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TenantDirectRequestBeforeYouApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TenantDirectRequestBeforeYouApply;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/data.js
@@ -280,4 +280,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "How to Apply",
+  description: "How to apply for a Tenant's Direct Request application.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/How-to-Apply/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TenantDirectRequestHowToApply() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TenantDirectRequestHowToApply;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/data.js
@@ -448,4 +448,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "What's Next",
+  description:
+    "What to expect after submitting a Tenant's Direct Request application.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/Whats-Next/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TenantDirectRequestWhatsNext() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TenantDirectRequestWhatsNext;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/data.js
@@ -209,4 +209,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Tenant's Direct Request",
+  description:
+    "Information about tenant's application for an expedited return of deposit, when a landlord has not returned the deposit or applied to keep all or some of the deposit.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/Tenant-Direct-Request/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function TenantDirectRequest() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default TenantDirectRequest;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/data.js
@@ -108,4 +108,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Dispute Resolution Applications",
+  description:
+    "Information about applying for dispute resolution through the Residential Tenancy Branch in B.C. for landlords and tenants.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/data.js
@@ -1,106 +1,111 @@
-const sections = [
+const content = [
   {
-    title: "",
-    cards: [
+    type: "navigation",
+    children: [
       {
-        title: "Apply for a Dispute Resolution Application",
-        description: "Resolve disputes related to a tenancy.",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications/online-dispute-resolution-application",
-          external: false,
-        },
-      },
-      {
-        title: "Apply for a Tenant Direct Request",
-        description:
-          "Apply for a Monetary Order for return of a security deposit and/or a pet damage deposit.",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications/tenant-direct-request",
-          external: false,
-        },
-      },
-      {
-        title: "Apply for a Landlord Direct Request",
-        description:
-          "Apply for a Monetary Order for return of a security deposit and/or a pet damage deposit.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Dispute Access Site",
-        description: "Are you a respondent? Add your evidence online!",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "View or Modify an Existing Application",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
+        cards: [
           {
-            href: "/under-construction",
-            label: "Amend or Update an Application",
+            title: "Apply for a Dispute Resolution Application",
+            description: "Resolve disputes related to a tenancy.",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications/online-dispute-resolution-application",
+              external: false,
+            },
           },
           {
-            href: "/under-construction",
-            label: "Make a Cross Application",
+            title: "Apply for a Tenant Direct Request",
+            description:
+              "Apply for a Monetary Order for return of a security deposit and/or a pet damage deposit.",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications/tenant-direct-request",
+              external: false,
+            },
           },
           {
-            href: "/under-construction",
-            label: "Join Applications",
+            title: "Apply for a Landlord Direct Request",
+            description:
+              "Apply for a Monetary Order for return of a security deposit and/or a pet damage deposit.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
           },
           {
-            href: "/under-construction",
-            label: "Withdraw an Application",
+            title: "Dispute Access Site",
+            description: "Are you a respondent? Add your evidence online!",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "View or Modify an Existing Application",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Amend or Update an Application",
+              },
+              {
+                href: "/under-construction",
+                label: "Make a Cross Application",
+              },
+              {
+                href: "/under-construction",
+                label: "Join Applications",
+              },
+              {
+                href: "/under-construction",
+                label: "Withdraw an Application",
+              },
+            ],
+          },
+          {
+            title:
+              "How to Complete a Paper Application for Dispute Resolutions",
+            description:
+              "Follow these tips and suggestions in completing your paper application for Dispute Resolution properly",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Hearing process",
+            description:
+              "Find important information about the dispute resolution and the dispute resolution hearing.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Prepare for your Hearing",
+            description:
+              "Find important information about the dispute resolution and the dispute resolution hearing.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Fees & Fee Waivers",
+            description:
+              "See filing fees for different dispute resolution applications and see if you qualify for a fee waiver",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
           },
         ],
-      },
-      {
-        title: "How to Complete a Paper Application for Dispute Resolutions",
-        description:
-          "Follow these tips and suggestions in completing your paper application for Dispute Resolution properly",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Hearing process",
-        description:
-          "Find important information about the dispute resolution and the dispute resolution hearing.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Prepare for your Hearing",
-        description:
-          "Find important information about the dispute resolution and the dispute resolution hearing.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Fees & Fee Waivers",
-        description:
-          "See filing fees for different dispute resolution applications and see if you qualify for a fee waiver",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
       },
     ],
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../../../components/Content";
+import { content } from "./data";
 
 function DisputeResolutionApplications() {
-  return <Navigation sections={sections} />;
+  return <Content content={content} />;
 }
 
 export default DisputeResolutionApplications;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Dispute-Resolution-Applications/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function DisputeResolutionApplications() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default DisputeResolutionApplications;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/data.js
@@ -698,4 +698,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Possession of the Unit",
+  description:
+    "Rights and responsibilities for landlords and tenants regarding possession of a unit.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Possession-of-the-Unit/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function PossessionOfTheUnit() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default PossessionOfTheUnit;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/data.js
@@ -274,4 +274,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Standard Rent Increases",
+  description: "Standard rent increase information for residential tenancies.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/Standard-Rent-Increases/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function StandardRentIncreases() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default StandardRentIncreases;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/data.js
@@ -351,4 +351,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Rent Increases",
+  description: "Rules regarding rent increases for residential tenancies.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/Rent-Increases/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function RentIncreases() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default RentIncreases;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
@@ -103,4 +103,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "During a Tenancy",
+  description: "Residential tenancy rules and regulations.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/data.js
@@ -1,102 +1,106 @@
-const sections = [
+const content = [
   {
-    title: "",
-    cards: [
+    type: "navigation",
+    children: [
       {
-        title: "Paying Rent",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Rent Increases",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
-          external: false,
-        },
-      },
-      {
-        title: "Repairs & Maintenance",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Landlord's Access",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Possession of the Unit",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/possession-of-the-unit",
-          external: false,
-        },
-      },
-      {
-        title: "Quiet Enjoyment",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Changes to the Agreement",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Pets",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Sublet & Assignment",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Selling a Tenanted Property",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Serving Notices During Tenancy",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Get it in Writing",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Cannabis",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
+        cards: [
+          {
+            title: "Paying Rent",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Rent Increases",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/rent-increases",
+              external: false,
+            },
+          },
+          {
+            title: "Repairs & Maintenance",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Landlord's Access",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Possession of the Unit",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy/possession-of-the-unit",
+              external: false,
+            },
+          },
+          {
+            title: "Quiet Enjoyment",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Changes to the Agreement",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Pets",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Sublet & Assignment",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Selling a Tenanted Property",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Serving Notices During Tenancy",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Get it in Writing",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Cannabis",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+        ],
       },
     ],
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../../../components/Content";
+import { content } from "./data";
 
 function DuringATenancy() {
-  return <Navigation sections={sections} />;
+  return <Content content={content} />;
 }
 
 export default DuringATenancy;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/During-a-Tenancy/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function DuringATenancy() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default DuringATenancy;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/data.js
@@ -1856,4 +1856,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Tenancy Forms",
+  description: "Residential Tenancy Branch forms for landlords and tenants.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/Forms/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function ResidentialTenancies() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default ResidentialTenancies;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
@@ -1,113 +1,121 @@
-const sections = [
+const content = [
   {
-    title: "Our Services",
-    cards: [
+    type: "navigation",
+    search: {
+      label: "Search Residential Tenancies",
+    },
+    children: [
       {
-        title: "Online Dispute Resolution Applications",
-        description:
-          "Apply or find information how to prepare for a dispute resolution application.",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications",
-          external: false,
-        },
+        title: "Our Services",
+        cards: [
+          {
+            title: "Online Dispute Resolution Applications",
+            description:
+              "Apply or find information how to prepare for a dispute resolution application.",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/dispute-resolution-applications",
+              external: false,
+            },
+          },
+          {
+            title: "Forms",
+            description:
+              "The forms page has new forms to make applying for dispute resolution easier.",
+            cardLink: {
+              href: "/themes/housing-and-tenancy/residential-tenancies/forms",
+              external: false,
+            },
+          },
+          {
+            title: "Resources and Calculators",
+            description:
+              "Discover publications and tools that will help you to understand your rights and responsibilities as a landlord or tenant.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+        ],
       },
       {
-        title: "Forms",
-        description:
-          "The forms page has new forms to make applying for dispute resolution easier.",
-        cardLink: {
-          href: "/themes/housing-and-tenancy/residential-tenancies/forms",
-          external: false,
-        },
-      },
-      {
-        title: "Resources and Calculators",
-        description:
-          "Discover publications and tools that will help you to understand your rights and responsibilities as a landlord or tenant.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-    ],
-  },
-  {
-    title: "Topics",
-    cards: [
-      {
-        title: "COVID-19",
-        description:
-          "Find updates to residential tenancies that impact landlords and renters due to the COVID-19 pandemic.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Is My Tenancy Covered Under B.C.'s Tenancy Laws?",
-        description:
-          "Find information and resolution services for residential tenancies.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Changes to Tenancy Laws",
-        description:
-          "Find updates to tenancy laws and how that impacts landlords and tenants.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Starting a Tenancy",
-        description:
-          "Find the rules and regulations that govern how residential properties or units are rented in B.C.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "During a Tenancy",
-        description:
-          "Learn your rights and responsibilities during a tenancy, including information on rent increases, repairs and maintenance.",
-        cardLink: {
-          href:
-            "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy",
-          external: false,
-        },
-      },
-      {
-        title: "Ending a Tenancy",
-        description: "Find more information on ending a tenancy.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Solving Problems",
-        description: "What to do when problems occur during a tenancy.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-      },
-      {
-        title: "Find it Fast",
-        description:
-          "A site map listing all the residential tenancies pages and subpages.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
+        title: "Topics",
+        cards: [
+          {
+            title: "COVID-19",
+            description:
+              "Find updates to residential tenancies that impact landlords and renters due to the COVID-19 pandemic.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Is My Tenancy Covered Under B.C.'s Tenancy Laws?",
+            description:
+              "Find information and resolution services for residential tenancies.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Changes to Tenancy Laws",
+            description:
+              "Find updates to tenancy laws and how that impacts landlords and tenants.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Starting a Tenancy",
+            description:
+              "Find the rules and regulations that govern how residential properties or units are rented in B.C.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "During a Tenancy",
+            description:
+              "Learn your rights and responsibilities during a tenancy, including information on rent increases, repairs and maintenance.",
+            cardLink: {
+              href:
+                "/themes/housing-and-tenancy/residential-tenancies/during-a-tenancy",
+              external: false,
+            },
+          },
+          {
+            title: "Ending a Tenancy",
+            description: "Find more information on ending a tenancy.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Solving Problems",
+            description: "What to do when problems occur during a tenancy.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+          {
+            title: "Find it Fast",
+            description:
+              "A site map listing all the residential tenancies pages and subpages.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+          },
+        ],
       },
     ],
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/data.js
@@ -118,4 +118,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Residential Tenancies",
+  description:
+    "Information about renting in B.C. and dispute resolution services through the Residential Tenancy Branch.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function ResidentialTenancies() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default ResidentialTenancies;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/Residential-Tenancies/index.js
@@ -1,15 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../../components/Content";
+import { content } from "./data";
 
 function ResidentialTenancies() {
-  return (
-    <Navigation
-      search={{ label: "Search Residential Tenancies" }}
-      sections={sections}
-    />
-  );
+  return <Content content={content} />;
 }
 
 export default ResidentialTenancies;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
@@ -1,161 +1,169 @@
-const sections = [
+const content = [
   {
-    title: "",
-    cards: [
+    type: "navigation",
+    search: {
+      label: "Search Housing & Tenancy",
+    },
+    children: [
       {
-        title: "Residential Tenancies",
-        cardLink: {
-          href: "/themes/housing-and-tenancy/residential-tenancies",
-          external: false,
-        },
-        description: "Info and services for tenants and landlords.",
-        links: [
+        cards: [
           {
-            href: "/under-construction",
-            label: "Tips for landlords & renters",
+            title: "Residential Tenancies",
+            cardLink: {
+              href: "/themes/housing-and-tenancy/residential-tenancies",
+              external: false,
+            },
+            description: "Info and services for tenants and landlords.",
+            links: [
+              {
+                href: "/under-construction",
+                label: "Tips for landlords & renters",
+              },
+              {
+                href: "/themes/housing-and-tenancy/residential-tenancies/forms",
+                label: "Tenancy Agreements",
+              },
+            ],
           },
           {
-            href: "/themes/housing-and-tenancy/residential-tenancies/forms",
-            label: "Tenancy Agreements",
-          },
-        ],
-      },
-      {
-        title: "Strata Housing",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        description:
-          "Find out information about strata housing, the role of a strata council, budgets and bylaws.",
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-        ],
-      },
-      {
-        title: "Owning a Home",
-        description: "Find all information you need about owning a home.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Strata Housing",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            description:
+              "Find out information about strata housing, the role of a strata council, budgets and bylaws.",
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-        ],
-      },
-      {
-        title: "Seniors Housing",
-        description: "Find housing options for seniors and older adults in BC.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Owning a Home",
+            description: "Find all information you need about owning a home.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-        ],
-      },
-      {
-        title: "Affordable Housing",
-        description:
-          "Learn more about affordable housing, social housing, the role of government and BC Housing.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-        ],
-      },
-      {
-        title: "Local Governments & Housing",
-        description:
-          "Find affordable housing tools and resources available to local governments.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Seniors Housing",
+            description:
+              "Find housing options for seniors and older adults in BC.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-        ],
-      },
-      {
-        title: "Building or Renovating",
-        description:
-          "Find resources you may need when building or renovating your home.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
-          },
-          {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Affordable Housing",
+            description:
+              "Learn more about affordable housing, social housing, the role of government and BC Housing.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Local Governments & Housing",
+            description:
+              "Find affordable housing tools and resources available to local governments.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
-        ],
-      },
-      {
-        title: "Real Estate in B.C.",
-        description:
-          "Learn about Real Estate in B.C.: buying and selling property, real estate consultations, and regulations.",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Building or Renovating",
+            description:
+              "Find resources you may need when building or renovating your home.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Quick links to popular pages",
+            title: "Real Estate in B.C.",
+            description:
+              "Learn about Real Estate in B.C.: buying and selling property, real estate consultations, and regulations.",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+              {
+                href: "/under-construction",
+                label: "Quick links to popular pages",
+              },
+            ],
           },
         ],
       },
@@ -163,4 +171,4 @@ const sections = [
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/data.js
@@ -171,4 +171,10 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Housing & Tenancy",
+  description:
+    "In B.C., whether you rent, own or are in need of housing, there are programs and information that can assist you.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
@@ -1,15 +1,10 @@
 import React from "react";
 
-import Navigation from "../../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../../components/Content";
+import { content } from "./data";
 
 function HousingAndTenancy() {
-  return (
-    <Navigation
-      search={{ label: "Search Housing & Tenancy" }}
-      sections={sections}
-    />
-  );
+  return <Content content={content} />;
 }
 
 export default HousingAndTenancy;

--- a/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
+++ b/react-app/src/pages/Themes/Housing-and-Tenancy/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function HousingAndTenancy() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default HousingAndTenancy;

--- a/react-app/src/pages/Themes/data.js
+++ b/react-app/src/pages/Themes/data.js
@@ -1,355 +1,362 @@
-const sections = [
+const content = [
   {
-    id: "themes",
-    title: "",
-    seeMoreLabel: "See More Topics",
-    cards: [
+    type: "navigation",
+    id: "topics",
+    search: {
+      label: "Search Topics",
+    },
+    children: [
       {
-        title: "Health",
-        icon: "heart-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
+        seeMoreLabel: "See More Topics",
+        cards: [
           {
-            href: "/under-construction",
-            label: "MSP",
+            title: "Health",
+            icon: "heart-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "MSP",
+              },
+              {
+                href: "/under-construction",
+                label: "PharmaCase for B.C. Residents",
+              },
+              {
+                href: "/under-construction",
+                label: "Health Forms",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "PharmaCase for B.C. Residents",
+            title: "Our Governments & Relations",
+            icon: "local-government.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Indigenous Peoples’ Relationship",
+              },
+              {
+                href: "/under-construction",
+                label: "BC Bid",
+              },
+              {
+                href: "/under-construction",
+                label: "BC Auction",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Health Forms",
-          },
-        ],
-      },
-      {
-        title: "Our Governments & Relations",
-        icon: "local-government.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Indigenous Peoples’ Relationship",
-          },
-          {
-            href: "/under-construction",
-            label: "BC Bid",
-          },
-          {
-            href: "/under-construction",
-            label: "BC Auction",
-          },
-        ],
-      },
-      {
-        title: "Taxes & Tax Credits",
-        icon: "dollar-sign-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Provincial Sales Tax",
+            title: "Taxes & Tax Credits",
+            icon: "dollar-sign-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Provincial Sales Tax",
+              },
+              {
+                href: "/under-construction",
+                label: "Speculation and Vacancy Tax",
+              },
+              {
+                href: "/under-construction",
+                label: "Property Transfer Tax",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Speculation and Vacancy Tax",
+            title: "Employment, Business & Economic Development",
+            icon: "material-work.svg",
+            cardLink: {
+              href: "/themes/employment-business-and-economic-development/",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Financial Supports for COVID-19",
+              },
+              {
+                href: "/under-construction",
+                label: "Economic Development",
+              },
+              {
+                href: "/under-construction",
+                label: "Funding & Grants Changes for Societies",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Property Transfer Tax",
-          },
-        ],
-      },
-      {
-        title: "Employment, Business & Economic Development",
-        icon: "material-work.svg",
-        cardLink: {
-          href: "/themes/employment-business-and-economic-development/",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Financial Supports for COVID-19",
-          },
-          {
-            href: "/under-construction",
-            label: "Economic Development",
-          },
-          {
-            href: "/under-construction",
-            label: "Funding & Grants Changes for Societies",
-          },
-        ],
-      },
-      {
-        title: "Family and Social Supports",
-        icon: "hands-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "MCFD Supports & Response to COVID-19",
+            title: "Family and Social Supports",
+            icon: "hands-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "MCFD Supports & Response to COVID-19",
+              },
+              {
+                href: "/under-construction",
+                label: "Helpline for Children",
+              },
+              {
+                href: "/under-construction",
+                label: "Poverty Reduction Strategy",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Helpline for Children",
+            title: "Public Safety & Emergency Services",
+            icon: "ambulance.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Current Wildfire Activity",
+              },
+              {
+                href: "/under-construction",
+                label: "Criminal Record Checks",
+              },
+              {
+                href: "/under-construction",
+                label: "Cannabis",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Poverty Reduction Strategy",
-          },
-        ],
-      },
-      {
-        title: "Public Safety & Emergency Services",
-        icon: "ambulance.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Current Wildfire Activity",
-          },
-          {
-            href: "/under-construction",
-            label: "Criminal Record Checks",
+            title: "Education and Training",
+            icon: "book-open-solid.svg",
+            cardLink: {
+              href: "/themes/education-and-training",
+              external: false,
+            },
+            links: [
+              {
+                href:
+                  "/themes/education-and-training/k-12/support/transcripts-and-certificates",
+                label: "Transcripts and Certificates",
+              },
+              {
+                href: "/under-construction",
+                label: "Blueprint Builder",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Cannabis",
-          },
-        ],
-      },
-      {
-        title: "Education and Training",
-        icon: "book-open-solid.svg",
-        cardLink: {
-          href: "/themes/education-and-training",
-          external: false,
-        },
-        links: [
-          {
-            href:
-              "/themes/education-and-training/k-12/support/transcripts-and-certificates",
-            label: "Transcripts and Certificates",
-          },
-          {
-            href: "/under-construction",
-            label: "Blueprint Builder",
-          },
-        ],
-      },
-      {
-        title: "Housing & Tenancy",
-        icon: "home-solid.svg",
-        cardLink: {
-          href: "/themes/housing-and-tenancy",
-          external: false,
-        },
-        links: [
-          {
-            href: "/themes/housing-and-tenancy/residential-tenancies",
-            label: "Renting a Home",
+            title: "Housing & Tenancy",
+            icon: "home-solid.svg",
+            cardLink: {
+              href: "/themes/housing-and-tenancy",
+              external: false,
+            },
+            links: [
+              {
+                href: "/themes/housing-and-tenancy/residential-tenancies",
+                label: "Renting a Home",
+              },
+              {
+                href: "/under-construction",
+                label: "Living in a Strata",
+              },
+              {
+                href: "/under-construction",
+                label: "Home Owner Grant",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Living in a Strata",
+            title: "Driving and Transporation",
+            icon: "car-alt-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Save Lives. Respect the Cone Zone",
+              },
+              {
+                href: "/under-construction",
+                label: "Intersection Safety Cameras",
+              },
+              {
+                href: "/under-construction",
+                label: "Commercial Transportation",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Home Owner Grant",
-          },
-        ],
-      },
-      {
-        title: "Driving and Transporation",
-        icon: "car-alt-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Save Lives. Respect the Cone Zone",
-          },
-          {
-            href: "/under-construction",
-            label: "Intersection Safety Cameras",
-          },
-          {
-            href: "/under-construction",
-            label: "Commercial Transportation",
-          },
-        ],
-      },
-      {
-        title: "Law, Crime & Justice",
-        icon: "map-icons-lawyer.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Pay eTickets on PayBC",
+            title: "Law, Crime & Justice",
+            icon: "map-icons-lawyer.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Pay eTickets on PayBC",
+              },
+              {
+                href: "/under-construction",
+                label: "Intersection Safety Cameras",
+              },
+              {
+                href: "/under-construction",
+                label: "Daily Court Lists",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Intersection Safety Cameras",
+            title: "Farming, Natural Resources & Industry",
+            icon: "industry-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "BC Building Code",
+              },
+              {
+                href: "/under-construction",
+                label: "Site C Information & Updates",
+              },
+              {
+                href: "/under-construction",
+                label: "Start a Farm",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Daily Court Lists",
-          },
-        ],
-      },
-      {
-        title: "Farming, Natural Resources & Industry",
-        icon: "industry-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "BC Building Code",
-          },
-          {
-            href: "/under-construction",
-            label: "Site C Information & Updates",
-          },
-          {
-            href: "/under-construction",
-            label: "Start a Farm",
-          },
-        ],
-      },
-      {
-        title: "Environmental Protection & Sustainability",
-        icon: "leaf-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "BC Parks",
+            title: "Environmental Protection & Sustainability",
+            icon: "leaf-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "BC Parks",
+              },
+              {
+                href: "/under-construction",
+                label: "B.C. Spill Response",
+              },
+              {
+                href: "/under-construction",
+                label: "Clean BC",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "B.C. Spill Response",
+            title: "Birth, Adoption, Death, Marriage and Identity",
+            icon: "hand-holding-heart-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Birth Registration & Birth Certificates",
+              },
+              {
+                href: "/under-construction",
+                label: "How to Get Married In BC",
+              },
+              {
+                href: "/under-construction",
+                label: "Legal Changes of Name",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Clean BC",
-          },
-        ],
-      },
-      {
-        title: "Birth, Adoption, Death, Marriage and Identity",
-        icon: "hand-holding-heart-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Birth Registration & Birth Certificates",
-          },
-          {
-            href: "/under-construction",
-            label: "How to Get Married In BC",
-          },
-          {
-            href: "/under-construction",
-            label: "Legal Changes of Name",
-          },
-        ],
-      },
-      {
-        title: "Sports, Recreation, Arts & Culture",
-        icon: "ios-football.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Book Your Camping Reservation",
+            title: "Sports, Recreation, Arts & Culture",
+            icon: "ios-football.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Book Your Camping Reservation",
+              },
+              {
+                href: "/under-construction",
+                label: "Arts and Culture Funding",
+              },
+              {
+                href: "/under-construction",
+                label: "Sport Participation",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Arts and Culture Funding",
+            title: "Data",
+            icon: "passport-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Data Innovation Program",
+              },
+              {
+                href: "/under-construction",
+                label: "Integrated Land & Resource Registry",
+              },
+              {
+                href: "/under-construction",
+                label: "Highlight on Technology",
+              },
+            ],
           },
           {
-            href: "/under-construction",
-            label: "Sport Participation",
-          },
-        ],
-      },
-      {
-        title: "Data",
-        icon: "passport-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Data Innovation Program",
-          },
-          {
-            href: "/under-construction",
-            label: "Integrated Land & Resource Registry",
-          },
-          {
-            href: "/under-construction",
-            label: "Highlight on Technology",
-          },
-        ],
-      },
-      {
-        title: "Moving to B.C. & Tourism",
-        icon: "plane-solid.svg",
-        cardLink: {
-          href: "/under-construction",
-          external: false,
-        },
-        links: [
-          {
-            href: "/under-construction",
-            label: "Get a B.C. Services Card",
-          },
-          {
-            href: "/under-construction",
-            label: "Moving to British Columbia",
-          },
-          {
-            href: "/under-construction",
-            label: "Travelling in B.C.",
+            title: "Moving to B.C. & Tourism",
+            icon: "plane-solid.svg",
+            cardLink: {
+              href: "/under-construction",
+              external: false,
+            },
+            links: [
+              {
+                href: "/under-construction",
+                label: "Get a B.C. Services Card",
+              },
+              {
+                href: "/under-construction",
+                label: "Moving to British Columbia",
+              },
+              {
+                href: "/under-construction",
+                label: "Travelling in B.C.",
+              },
+            ],
           },
         ],
       },
@@ -357,4 +364,4 @@ const sections = [
   },
 ];
 
-export { sections };
+export { content };

--- a/react-app/src/pages/Themes/data.js
+++ b/react-app/src/pages/Themes/data.js
@@ -364,4 +364,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Topics",
+  description: "Content topics on the BC Government website.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Themes/index.js
+++ b/react-app/src/pages/Themes/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function Themes() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default Themes;

--- a/react-app/src/pages/Themes/index.js
+++ b/react-app/src/pages/Themes/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-import Navigation from "../../components/Navigation";
-import { sections } from "./data";
+import Content from "../../components/Content";
+import { content } from "./data";
 
 function Themes() {
-  return <Navigation search={{ label: "Search Topics" }} sections={sections} />;
+  return <Content content={content} />;
 }
 
 export default Themes;

--- a/react-app/src/pages/Under-Construction/data.js
+++ b/react-app/src/pages/Under-Construction/data.js
@@ -16,4 +16,9 @@ const content = [
   },
 ];
 
-export { content };
+const metadata = {
+  title: "Under Construction",
+  description: "This page isn't finished yet.",
+};
+
+export { content, metadata };

--- a/react-app/src/pages/Under-Construction/index.js
+++ b/react-app/src/pages/Under-Construction/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 
 import Content from "../../components/Content";
-import { content } from "./data";
+import { content, metadata } from "./data";
 
 function UnderConstruction() {
-  return <Content content={content} />;
+  return <Content content={content} metadata={metadata} />;
 }
 
 export default UnderConstruction;


### PR DESCRIPTION
This PR adds `react-helmet` to the front-end app for setting page titles and meta description tag data dynamically on a per-page basis.

A default page title and meta description are added to the `./react-app/src/PrivateRoute.js` (0626d84) to allow the non-private Login and Logout pages to have page titles that don't use the templated site title (`%s - Province of British Columbia`). Then, page-specific titles are set in each page's data through the Content component. In the future when there is no need for authentication in front of the prototype app, this logic can probably live right in the App component itself.

Additionally, all navigation-style pages are now using the Content component directly, with Navigation components as children if they are "pure" navigation pages. Example: 033e22e.

All existing pages have their data updated with page titles and meta descriptions to allow for future search indexing tests.

Front-end dependencies are bumped in 9276f80.