### PR TITLE
Search engine result page foundations

### DIFF
--- a/data/search/xml/default-no-results.xml
+++ b/data/search/xml/default-no-results.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GSP VER="3.2">
+   <TM>0</TM>
+   <Q></Q>
+   <PARAM name="site" value="default_collection"/>
+   <PARAM name="client" value="default_frontend"/>
+   <PARAM name="q" value=""/>
+   <PARAM name="partialfields" value=""/>
+   <PARAM name="requiredfields" value=""/>
+</GSP>

--- a/data/search/xml/jobs.xml
+++ b/data/search/xml/jobs.xml
@@ -1,0 +1,777 @@
+<?xml version="1.0" encoding="UTF-8"?><GSP xmlns:xs="http://www.w3.org/2001/XMLSchema" VER="3.2">
+   <TM>0.629000</TM>
+   <Q>jobs</Q>
+   <PARAM name="site" original_value="default_collection" value="default_collection"/>
+   <PARAM name="client" original_value="default_frontend" value="default_frontend"/>
+   <PARAM name="start" original_value="0" value="0"/>
+   <PARAM name="getfields" original_value="*" value="*"/>
+   <PARAM name="q" original_value="jobs" value="jobs"/>
+   <RES EN="10" SN="1">
+      <M>35200</M>
+      <FI/>
+      <NB>
+         <NU>/search?site=default_collection&amp;client=default_frontend&amp;q=jobs&amp;start=10</NU>
+      </NB>
+      <R N="1">
+         <U>https://www2.gov.bc.ca/gov/content/industry/forestry/supporting-innovation/bio-economy/bioeconomy-jobs</U>
+         <UE>https://www2.gov.bc.ca/gov/content/industry/forestry/supporting-innovation/bio-economy/bioeconomy-jobs</UE>
+         <T>Bioeconomy and Jobs - Province of British Columbia</T>
+         <RK>67.45877412513761</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2021-03-10"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1615336241539"/>
+         <MT N="DCSext.creator" V="Ministry of Forests, Lands, Natural Resource Operations and Rural Development"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Forestry"/>
+         <MT N="DCTERMS.subject" V="Biomass"/>
+         <MT N="DCTERMS.subject" V="Technological innovation"/>
+         <MT N="DCTERMS.subject" V="Job creation"/>
+         <MT N="level1_id" V="A389E49687F74532A306249A234EDF29"/>
+         <MT N="keywords" V="bioeconomy, bioproducts, jobs, employment, biomaterials, biochemicals"/>
+         <MT N="DCSext.current_page" V="Bioeconomy and Jobs"/>
+         <MT N="mes:date" V="1615336241000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Bioeconomy and Jobs - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="AA59C0AA67DA452486989F5C088CF0C2"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2020-11-23"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/industry/forestry/supporting-innovation/bio-economy/bioeconomy-jobs"/>
+         <MT N="DCTERMS.modified" V="2020-12-07"/>
+         <MT N="DCTERMS.creator" V="Ministry of Forests, Lands, Natural Resource Operations and Rural Development"/>
+         <MT N="current_page" V="Bioeconomy and Jobs"/>
+         <MT N="DCSext.level3" V="Supporting Innovation"/>
+         <MT N="DCSext.level4" V="Bioeconomy"/>
+         <MT N="DCSext.level5" V="Bioeconomy and Jobs"/>
+         <MT N="DCSext.level1" V="Farming, natural resources and industry"/>
+         <MT N="DCSext.level2" V="Forestry"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="An evaluation of jobs created within each category of advanced forest bioproducts."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="0D9F7A7D9A6545239C7AC36BFBA40100"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="107053.0"/>
+         <MT N="level5" V="Bioeconomy and Jobs"/>
+         <MT N="level4" V="Bioeconomy"/>
+         <MT N="current_page_id" V="7A12C52C987343E3A95D03E521F1525E"/>
+         <MT N="level1" V="Farming natural resources and industry"/>
+         <MT N="level3" V="Supporting Innovation"/>
+         <MT N="level2" V="Forestry"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="73E3AA37537B494F9C1FF9600BF2FD48"/>
+         <MT N="navigaton_title" V="Bioeconomy and Jobs"/>
+         <MT N="MBCTERMS.subjectCategory" V="Science and Technology"/>
+         <MT N="MBCTERMS.subjectCategory" V="Nature and Environment"/>
+         <MT N="level5_id" V="7A12C52C987343E3A95D03E521F1525E"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Development
+Bioeconomy and &lt;b&gt;Jobs&lt;/b&gt;
+Biomass Technology
+Indigenous...Glossary
+Bioeconomy and &lt;b&gt;Jobs&lt;/b&gt;
+The bioproduct-&lt;b&gt;jobs&lt;/b&gt; pyramid shows all...direct and indirect &lt;b&gt;jobs&lt;/b&gt; supported through manufacturing...manufacturing of bioproducts. &lt;b&gt;Job&lt;/b&gt; creation correlates with...will be. These &lt;b&gt;job&lt;/b&gt; estimates are per...have slightly different &lt;b&gt;job&lt;/b&gt; estimates.  This approach provides &lt;b&gt;job&lt;/b&gt; estimates for a...approximately 0.4 &lt;b&gt;jobs&lt;/b&gt; when looking at</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="104.54k"/>
+         </HAS>
+      </R>
+      <R N="2">
+         <U>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness</U>
+         <UE>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness</UE>
+         <T>Ministry of Jobs, Economic Recovery and Innovation - Province of British Columbia</T>
+         <RK>65.53527343724016</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2021-01-27"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1611774334536"/>
+         <MT N="DCSext.creator" V="Ministry of Jobs, Economic Recovery and Innovation"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Ministries"/>
+         <MT N="DCTERMS.subject" V="Job search"/>
+         <MT N="DCTERMS.subject" V="Labour"/>
+         <MT N="DCTERMS.subject" V="Skills"/>
+         <MT N="level1_id" V="1BCDDAA9ED30487784F29ADC800E5DCB"/>
+         <MT N="keywords" V="Ministry of Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.current_page" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="mes:date" V="1611774334000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Ministry of Jobs, Economic Recovery and Innovation - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="259D3A1F1BCB8D601B13742603415970"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-03-28"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness"/>
+         <MT N="DCTERMS.modified" V="2021-01-27"/>
+         <MT N="DCTERMS.creator" V="Ministry of Jobs, Economic Recovery and Innovation"/>
+         <MT N="current_page" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.level3" V="Ministries and organizations"/>
+         <MT N="DCSext.level4" V="Ministries"/>
+         <MT N="DCSext.level5" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.level1" V="British Columbians and our governments"/>
+         <MT N="DCSext.level2" V="Organizational structure"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="The Ministry of Jobs, Economic Recovery and Innovation manages government services that help support and maintain the strong and diverse economy that British Columbians need for long-term prosperity. It supports the growth of BC’s tech sector, champions innovation across the economy, nurtures small businesses, supports economic development throughout the province, and promotes BC internationally as a preferred place to invest and do business."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="F024503C72F64D8380441972977188D6"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="116022.0"/>
+         <MT N="Synonyms" V="Ministry of Jobs, Economic Development and Competitiveness"/>
+         <MT N="level5" V="Jobs Economic Recovery and Innovation"/>
+         <MT N="level4" V="Ministries"/>
+         <MT N="current_page_id" V="831A1A6B9E0449A1871F8FE1C5AD98D0"/>
+         <MT N="level1" V="British Columbians and our governments"/>
+         <MT N="level3" V="Ministries and organizations"/>
+         <MT N="level2" V="Organizational structure"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="level4_id" V="70177F69BACC46A2B57ED1510B87EF1A"/>
+         <MT N="navigaton_title" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="MBCTERMS.subjectCategory" V="Government and Politics"/>
+         <MT N="level5_id" V="831A1A6B9E0449A1871F8FE1C5AD98D0"/>
+         <MT N="DCTERMS.audience" V="General Public"/>
+         <MT N="DCTERMS.audience" V="Students"/>
+         <MT N="DCTERMS.audience" V="Business Owners"/>
+         <MT N="DCTERMS.audience" V="Veterans"/>
+         <MT N="DCTERMS.audience" V="Parents and Guardians"/>
+         <MT N="DCTERMS.audience" V="Women"/>
+         <MT N="DCTERMS.audience" V="Men"/>
+         <MT N="DCTERMS.audience" V="Youth"/>
+         <MT N="DCTERMS.audience" V="Indigenous Peoples"/>
+         <MT N="DCTERMS.audience" V="Employers"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Relations and Reconciliation
+&lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...tribunals
+Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...The Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...care, create good &lt;b&gt;jobs&lt;/b&gt; and opportunities for...Kahlon
+Minister of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...Minister, Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="113.3k"/>
+         </HAS>
+      </R>
+      <R N="3">
+         <U>https://www2.gov.bc.ca/gov/content/careers-myhr/job-seekers/featured-careers/living-working-northern-bc/jobs</U>
+         <UE>https://www2.gov.bc.ca/gov/content/careers-myhr/job-seekers/featured-careers/living-working-northern-bc/jobs</UE>
+         <T>Jobs in B.C.'s North - Province of British Columbia</T>
+         <RK>63.59802274442533</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-14"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1607975419681"/>
+         <MT N="DCSext.creator" V="BC Public Service Agency"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Employment opportunities"/>
+         <MT N="level1_id" V="C6D1F618844441778AD409A9C99C1CD3"/>
+         <MT N="keywords" V="job opportunities, northern B.C."/>
+         <MT N="DCSext.current_page" V="Jobs in B.C.'s North"/>
+         <MT N="mes:date" V="1607975419000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Jobs in B.C.'s North - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="F081E268A380420D82C9668AE1CEA660"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="6EACC0EFAF23431F8553E28D171EFDB6"/>
+         <MT N="content_group_id" V="CE385D1D7A0F4C6F8CF90895950CF6A4"/>
+         <MT N="content_group_id" V="3F08B3480E6C400097ECF5D0AB017B70"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="bcpsa_audiences" V="Job seekers and applicants"/>
+         <MT N="DCTERMS.created" V="2016-02-17"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/careers-myhr/job-seekers/featured-careers/living-working-northern-bc/jobs"/>
+         <MT N="DCTERMS.modified" V="2020-12-14"/>
+         <MT N="DCTERMS.creator" V="BC Public Service Agency"/>
+         <MT N="bcpsa_subjects" V="Job vacancies"/>
+         <MT N="bcpsa_enhancedSearch" V="myhr"/>
+         <MT N="current_page" V="Jobs in B.C.'s North"/>
+         <MT N="DCSext.level3" V="Featured Careers"/>
+         <MT N="DCSext.level4" V="Living &amp; Working in Northern B.C."/>
+         <MT N="DCSext.level5" V="Jobs in B.C.'s North"/>
+         <MT N="DCSext.level1" V="Careers and MyHR"/>
+         <MT N="DCSext.level2" V="Job Seekers"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Information on the current job opportunities in northern B.C."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="FE00A3AE5AE846EC8DED6B4FCD945CB3"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="111851.0"/>
+         <MT N="level5" V="Jobs in B.C.'s North"/>
+         <MT N="level4" V="Living &amp; Working in Northern B.C."/>
+         <MT N="current_page_id" V="2E478E3C14444F16AEBFCA7429D9D55F"/>
+         <MT N="level1" V="Careers and MyHR"/>
+         <MT N="level3" V="Featured Careers"/>
+         <MT N="level2" V="Job Seekers"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_psa"/>
+         <MT N="content_group" V="CMF_gov_PSA_Analytics"/>
+         <MT N="content_group" V="CMF_gov_psa_subtheme"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="DBC0EFFFE4BF46C4928ACDA69384236E"/>
+         <MT N="navigaton_title" V="Jobs in B.C.'s North"/>
+         <MT N="MBCTERMS.subjectCategory" V="Labour"/>
+         <MT N="level5_id" V="2E478E3C14444F16AEBFCA7429D9D55F"/>
+         <MT N="DCTERMS.audience" V="Job Seekers"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Careers and MyHR &lt;b&gt;Job&lt;/b&gt; Seekers Featured Careers...Northern B.C.
+&lt;b&gt;Jobs&lt;/b&gt; in B.C.'s...Sector Career Opportunities
+&lt;b&gt;Jobs&lt;/b&gt; in B.C.'s...and apply
+Current &lt;b&gt;Job&lt;/b&gt; Opportunities
+BC Public</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="109.23k"/>
+         </HAS>
+      </R>
+      <R N="4">
+         <U>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/ministry-contacts</U>
+         <UE>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/ministry-contacts</UE>
+         <T>Ministry of Jobs, Economic Recovery and Innovation - Province of British Columbia</T>
+         <RK>63.29077263454412</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-07"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1607380526407"/>
+         <MT N="DCSext.creator" V="Ministry of Jobs, Economic Recovery and Innovation"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Tourism"/>
+         <MT N="DCTERMS.subject" V="Labour"/>
+         <MT N="level1_id" V="1BCDDAA9ED30487784F29ADC800E5DCB"/>
+         <MT N="keywords" V="contacts"/>
+         <MT N="DCSext.current_page" V="Ministry Contacts"/>
+         <MT N="mes:date" V="1607380526000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Ministry of Jobs, Economic Recovery and Innovation - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="259D3A1F1BCB8D601B13742603415970"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-03-28"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/ministry-contacts"/>
+         <MT N="DCTERMS.modified" V="2020-12-07"/>
+         <MT N="DCTERMS.creator" V="Ministry of Jobs, Economic Recovery and Innovation"/>
+         <MT N="current_page" V="Ministry Contacts"/>
+         <MT N="level6_id" V="1A31C8C161724FA4AA28044C329666B5"/>
+         <MT N="DCSext.level3" V="Ministries and organizations"/>
+         <MT N="DCSext.level4" V="Ministries"/>
+         <MT N="DCSext.level5" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.level6" V="Ministry Contacts"/>
+         <MT N="DCSext.level1" V="British Columbians and our governments"/>
+         <MT N="DCSext.level2" V="Organizational structure"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Ministry of Jobs, Trade and Technology"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="F024503C72F64D8380441972977188D6"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="110537.0"/>
+         <MT N="level5" V="Jobs Economic Recovery and Innovation"/>
+         <MT N="level4" V="Ministries"/>
+         <MT N="level6" V="Ministry Contacts"/>
+         <MT N="current_page_id" V="1A31C8C161724FA4AA28044C329666B5"/>
+         <MT N="level1" V="British Columbians and our governments"/>
+         <MT N="level3" V="Ministries and organizations"/>
+         <MT N="level2" V="Organizational structure"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="level4_id" V="70177F69BACC46A2B57ED1510B87EF1A"/>
+         <MT N="navigaton_title" V="Ministry Contacts"/>
+         <MT N="MBCTERMS.subjectCategory" V="Government and Politics"/>
+         <MT N="level5_id" V="831A1A6B9E0449A1871F8FE1C5AD98D0"/>
+         <MT N="DCTERMS.audience" V="General Public"/>
+         <MT N="DCTERMS.audience" V="Students"/>
+         <MT N="DCTERMS.audience" V="Business Owners"/>
+         <MT N="DCTERMS.audience" V="Women"/>
+         <MT N="DCTERMS.audience" V="Men"/>
+         <MT N="DCTERMS.audience" V="Persons with Disabilities"/>
+         <MT N="DCTERMS.audience" V="Seniors"/>
+         <MT N="DCTERMS.audience" V="Indigenous Peoples"/>
+         <MT N="DCTERMS.audience" V="Employers"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>and organizations Ministries &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...Relations and Reconciliation
+&lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...tribunals
+Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...Kahlon
+Minister of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="107.95k"/>
+         </HAS>
+      </R>
+      <R N="5">
+         <U>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/annual-report</U>
+         <UE>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/annual-report</UE>
+         <T>Ministry of Jobs, Economic Recovery and Innovation Annual Report - Province of British Columbia</T>
+         <RK>63.28977263418649</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-07"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1607379625160"/>
+         <MT N="DCSext.creator" V="Government Communications and Public Engagement"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Strategic management"/>
+         <MT N="DCTERMS.subject" V="Guidelines"/>
+         <MT N="DCTERMS.subject" V="Benchmarks"/>
+         <MT N="DCTERMS.subject" V="Budgets"/>
+         <MT N="DCTERMS.subject" V="Performance indicators"/>
+         <MT N="DCTERMS.subject" V="Strategies"/>
+         <MT N="level1_id" V="1BCDDAA9ED30487784F29ADC800E5DCB"/>
+         <MT N="keywords" V="Annual Reports, Performance Measures, Processes, Milestones, Deliverable, Budget"/>
+         <MT N="DCSext.current_page" V="Annual Report"/>
+         <MT N="mes:date" V="1607379625000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Ministry of Jobs, Economic Recovery and Innovation Annual Report - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="259D3A1F1BCB8D601B13742603415970"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-10-30"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/annual-report"/>
+         <MT N="DCTERMS.modified" V="2020-12-07"/>
+         <MT N="DCTERMS.creator" V="Government Communications and Public Engagement"/>
+         <MT N="current_page" V="Annual Report"/>
+         <MT N="level6_id" V="66A0A2600DBD4E74B36829341D0D1953"/>
+         <MT N="DCSext.level3" V="Ministries and organizations"/>
+         <MT N="DCSext.level4" V="Ministries"/>
+         <MT N="DCSext.level5" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.level6" V="Annual Report"/>
+         <MT N="DCSext.level1" V="British Columbians and our governments"/>
+         <MT N="DCSext.level2" V="Organizational structure"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Each ministry is required by the Budget Transparency and Accountability Act (BTAA) to issue an annual report."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="F024503C72F64D8380441972977188D6"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="110089.0"/>
+         <MT N="level5" V="Jobs Economic Recovery and Innovation"/>
+         <MT N="level4" V="Ministries"/>
+         <MT N="level6" V="Annual Report"/>
+         <MT N="current_page_id" V="66A0A2600DBD4E74B36829341D0D1953"/>
+         <MT N="level1" V="British Columbians and our governments"/>
+         <MT N="level3" V="Ministries and organizations"/>
+         <MT N="level2" V="Organizational structure"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="CMF_ContentType" V="Reports"/>
+         <MT N="level4_id" V="70177F69BACC46A2B57ED1510B87EF1A"/>
+         <MT N="navigaton_title" V="Annual Report"/>
+         <MT N="MBCTERMS.subjectCategory" V="Processes"/>
+         <MT N="MBCTERMS.subjectCategory" V="Government and Politics"/>
+         <MT N="level5_id" V="831A1A6B9E0449A1871F8FE1C5AD98D0"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>and organizations Ministries &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...Relations and Reconciliation
+&lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...tribunals
+Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="107.51k"/>
+         </HAS>
+      </R>
+      <R N="6">
+         <U>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/service-plan</U>
+         <UE>https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/service-plan</UE>
+         <T>Ministry of Jobs, Economic Recovery and Innovation Service Plan - Province of British Columbia</T>
+         <RK>63.28977263418649</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-07"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1607379627306"/>
+         <MT N="DCSext.creator" V="Government Communications and Public Engagement"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Guidelines"/>
+         <MT N="DCTERMS.subject" V="Benchmarks"/>
+         <MT N="DCTERMS.subject" V="Budgets"/>
+         <MT N="DCTERMS.subject" V="Budget planning"/>
+         <MT N="DCTERMS.subject" V="Performance indicators"/>
+         <MT N="level1_id" V="1BCDDAA9ED30487784F29ADC800E5DCB"/>
+         <MT N="keywords" V="Service Plan, Performance Measures, Auditing, Processes, Assessment, Benchmarks"/>
+         <MT N="DCSext.current_page" V="Service Plan"/>
+         <MT N="mes:date" V="1607379627000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Ministry of Jobs, Economic Recovery and Innovation Service Plan - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="259D3A1F1BCB8D601B13742603415970"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-10-30"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/jobs-economic-development-and-competitiveness/service-plan"/>
+         <MT N="DCTERMS.modified" V="2020-12-07"/>
+         <MT N="DCTERMS.creator" V="Government Communications and Public Engagement"/>
+         <MT N="current_page" V="Service Plan"/>
+         <MT N="level6_id" V="0B54519D0D0C4ACF905E06936D5FFDE1"/>
+         <MT N="DCSext.level3" V="Ministries and organizations"/>
+         <MT N="DCSext.level4" V="Ministries"/>
+         <MT N="DCSext.level5" V="Jobs, Economic Recovery and Innovation"/>
+         <MT N="DCSext.level6" V="Service Plan"/>
+         <MT N="DCSext.level1" V="British Columbians and our governments"/>
+         <MT N="DCSext.level2" V="Organizational structure"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Each ministry is required by the Budget Transparency and Accountability Act (BTAA) to create and publish a service plan annually."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="F024503C72F64D8380441972977188D6"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="109781.0"/>
+         <MT N="level5" V="Jobs Economic Recovery and Innovation"/>
+         <MT N="level4" V="Ministries"/>
+         <MT N="level6" V="Service Plan"/>
+         <MT N="current_page_id" V="0B54519D0D0C4ACF905E06936D5FFDE1"/>
+         <MT N="level1" V="British Columbians and our governments"/>
+         <MT N="level3" V="Ministries and organizations"/>
+         <MT N="level2" V="Organizational structure"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="CMF_ContentType" V="Reports"/>
+         <MT N="level4_id" V="70177F69BACC46A2B57ED1510B87EF1A"/>
+         <MT N="navigaton_title" V="Service Plan"/>
+         <MT N="MBCTERMS.subjectCategory" V="Processes"/>
+         <MT N="MBCTERMS.subjectCategory" V="Government and Politics"/>
+         <MT N="level5_id" V="831A1A6B9E0449A1871F8FE1C5AD98D0"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>and organizations Ministries &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...Relations and Reconciliation
+&lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and...tribunals
+Ministry of &lt;b&gt;Jobs&lt;/b&gt;, Economic Recovery and</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="107.21k"/>
+         </HAS>
+      </R>
+      <R N="7">
+         <U>https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/exploration-in-bc/bc-mining-jobs-task-force</U>
+         <UE>https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/exploration-in-bc/bc-mining-jobs-task-force</UE>
+         <T>B.C. Mining Jobs Task Force - Province of British Columbia</T>
+         <RK>63.08677256158801</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-02"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1606873591727"/>
+         <MT N="DCSext.creator" V="Ministry of Energy, Mines and Low Carbon Innovation"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Mining industry"/>
+         <MT N="DCTERMS.subject" V="Job creation"/>
+         <MT N="DCTERMS.subject" V="Environmental economics"/>
+         <MT N="level1_id" V="A389E49687F74532A306249A234EDF29"/>
+         <MT N="keywords" V="Mining jobs task force, mining industry, mineral exploration, mining investment"/>
+         <MT N="DCSext.current_page" V="B.C. Mining Jobs Task Force"/>
+         <MT N="mes:date" V="1606873591000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="B.C. Mining Jobs Task Force - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="AA22BBB6335F43EE92ECE1FC84F9DA35"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2018-02-23"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/exploration-in-bc/bc-mining-jobs-task-force"/>
+         <MT N="DCTERMS.modified" V="2019-02-07"/>
+         <MT N="DCTERMS.creator" V="Ministry of Energy, Mines and Low Carbon Innovation"/>
+         <MT N="current_page" V="B.C. Mining Jobs Task Force"/>
+         <MT N="DCSext.level3" V="Mineral &amp; Coal Exploration"/>
+         <MT N="DCSext.level4" V="B.C. Mining Jobs Task Force"/>
+         <MT N="DCSext.level1" V="Farming, natural resources and industry"/>
+         <MT N="DCSext.level2" V="Mineral Exploration &amp; Mining"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Information on the B.C. Mining Jobs Task Force"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="2FA7C7387A944D0B89ED6C466ACE43D1"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="103511.0"/>
+         <MT N="level4" V="B.C. Mining Jobs Task Force"/>
+         <MT N="current_page_id" V="EBA85CE86746434F8AE7CDD5E6AD2A5C"/>
+         <MT N="level1" V="Farming natural resources and industry"/>
+         <MT N="level3" V="Mineral &amp; Coal Exploration"/>
+         <MT N="level2" V="Mineral Exploration &amp; Mining"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="EBA85CE86746434F8AE7CDD5E6AD2A5C"/>
+         <MT N="navigaton_title" V="B.C. Mining Jobs Task Force"/>
+         <MT N="MBCTERMS.subjectCategory" V="Economics and Industry"/>
+         <MT N="MBCTERMS.subjectCategory" V="Nature and Environment"/>
+         <MT N="MBCTERMS.subjectCategory" V="Government and Politics"/>
+         <MT N="DCTERMS.audience" V="General Public"/>
+         <MT N="DCTERMS.audience" V="Indigenous Peoples"/>
+         <MT N="DCTERMS.audience" V="Local Government"/>
+         <MT N="DCTERMS.audience" V="Provincial Government"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>B.C. Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force
+B.C. Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force
+Minister...B.C. Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force on...B.C. provide &lt;b&gt;jobs&lt;/b&gt; for more than...and create good &lt;b&gt;jobs&lt;/b&gt; for people today...Read the Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force - Final...Reference
+The Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force terms...B.C. Mining &lt;b&gt;Jobs&lt;/b&gt; Task Force Terms</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="101.08k"/>
+         </HAS>
+      </R>
+      <R N="8">
+         <U>https://www2.gov.bc.ca/gov/content/industry/natural-gas-oil/lng/lng-projects/lng-canada-39828</U>
+         <UE>https://www2.gov.bc.ca/gov/content/industry/natural-gas-oil/lng/lng-projects/lng-canada-39828</UE>
+         <T>LNG Canada - Jobs and Skills Training - Province of British Columbia</T>
+         <RK>63.02877254084558</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-02"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1606873317010"/>
+         <MT N="DCSext.creator" V="Ministry of Energy, Mines and Low Carbon Innovation"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Job creation"/>
+         <MT N="DCTERMS.subject" V="Job search"/>
+         <MT N="DCTERMS.subject" V="Skills"/>
+         <MT N="DCTERMS.subject" V="Fuels"/>
+         <MT N="DCTERMS.subject" V="Natural gas"/>
+         <MT N="DCTERMS.subject" V="Liquefied natural gas"/>
+         <MT N="level1_id" V="A389E49687F74532A306249A234EDF29"/>
+         <MT N="keywords" V="Liquefied Natural Gas, LNG, Projects, LNG projects, LNG Canada, Jobs, Skills Training"/>
+         <MT N="DCSext.current_page" V="LNG Canada - Jobs and Skills Training"/>
+         <MT N="mes:date" V="1606873317000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="LNG Canada - Jobs and Skills Training - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="6A5F45A4B8B74D86BDA54AF4DD90F3E8"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2019-06-17"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/industry/natural-gas-oil/lng/lng-projects/lng-canada-39828"/>
+         <MT N="DCTERMS.modified" V="2019-08-29"/>
+         <MT N="DCTERMS.creator" V="Ministry of Energy, Mines and Low Carbon Innovation"/>
+         <MT N="current_page" V="LNG Canada - Jobs and Skills Training"/>
+         <MT N="DCSext.level3" V="Liquefied Natural Gas"/>
+         <MT N="DCSext.level4" V="LNG Projects"/>
+         <MT N="DCSext.level5" V="LNG Canada - Jobs and Skills Training"/>
+         <MT N="DCSext.level1" V="Farming, natural resources and industry"/>
+         <MT N="DCSext.level2" V="Natural Gas &amp; Oil"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Information about jobs and skills training as it relates to LNG Canada"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="BC0C37E671F444CB9FD3F69DA139625B"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="108143.0"/>
+         <MT N="level5" V="LNG Canada - Jobs and Skills Training"/>
+         <MT N="level4" V="LNG Projects"/>
+         <MT N="current_page_id" V="AB159E28200144D7BAE250BFE4605F13"/>
+         <MT N="level1" V="Farming natural resources and industry"/>
+         <MT N="level3" V="Liquefied Natural Gas"/>
+         <MT N="level2" V="Natural Gas &amp; Oil"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="E31C23C74C3B49EDB847A266E5F26D32"/>
+         <MT N="navigaton_title" V="LNG Canada - Jobs and Skills Training"/>
+         <MT N="MBCTERMS.subjectCategory" V="Education and Training"/>
+         <MT N="MBCTERMS.subjectCategory" V="Economics and Industry"/>
+         <MT N="MBCTERMS.subjectCategory" V="Nature and Environment"/>
+         <MT N="level5_id" V="AB159E28200144D7BAE250BFE4605F13"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Canada
+LNG Canada - &lt;b&gt;Jobs&lt;/b&gt; and Skills Training...LNG
+LNG Canada - &lt;b&gt;Jobs&lt;/b&gt; and Skills Training...Most of these &lt;b&gt;job&lt;/b&gt; opportunities are created...Canada, to offer &lt;b&gt;jobs&lt;/b&gt; and training for...ultimately find a &lt;b&gt;job&lt;/b&gt;.
+There are WorkBC...and find a &lt;b&gt;job&lt;/b&gt;. Career Compass –...Find details on &lt;b&gt;jobs&lt;/b&gt;, including salary, duties...the skilled trades.
+&lt;b&gt;Job&lt;/b&gt; Search
+WorkBC &lt;b&gt;Job&lt;/b&gt; Search – Access thousands of &lt;b&gt;job&lt;/b&gt; postings throughout the</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="105.61k"/>
+         </HAS>
+      </R>
+      <R N="9">
+         <U>https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/creston-valley-mobile-press</U>
+         <UE>https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/creston-valley-mobile-press</UE>
+         <T>Regional Partnership Creates Value-Added Food Products and Local Jobs - Province of British Columbia</T>
+         <RK>62.31402228523098</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-06-24"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1593013007796"/>
+         <MT N="DCSext.creator" V="Ministry of Jobs Tourism and Skills Training"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Local governments"/>
+         <MT N="DCTERMS.subject" V="Rural communities"/>
+         <MT N="DCTERMS.subject" V="Community development"/>
+         <MT N="DCTERMS.subject" V="Economic development"/>
+         <MT N="DCTERMS.subject" V="Forestry"/>
+         <MT N="DCTERMS.subject" V="Best practices"/>
+         <MT N="level1_id" V="820A75B4A1AF426C9450E4ADF0D1D783"/>
+         <MT N="keywords" V="Economic Development Success Story, Wildwood Ecoforest, Ecoforestry Institute Society, sustainability, old growth ecosystem"/>
+         <MT N="DCSext.current_page" V="Mobile Produce Press"/>
+         <MT N="mes:date" V="1593013007000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Regional Partnership Creates Value-Added Food Products and Local Jobs - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="5D55B284D4A34B58B5DC1341CF976083"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="7958EA9A19784188A8A726CD8E8A6533"/>
+         <MT N="content_group_id" V="C9ECEF9A59E244C88A7BA3FFA40CF968"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2017-12-29"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/creston-valley-mobile-press"/>
+         <MT N="DCTERMS.modified" V="2020-06-01"/>
+         <MT N="DCTERMS.creator" V="Ministry of Jobs Tourism and Skills Training"/>
+         <MT N="current_page" V="Mobile Produce Press"/>
+         <MT N="level6_id" V="CB3451659ECE4C4B9219D34E8099A8D4"/>
+         <MT N="DCSext.level3" V="BC Ideas Exchange: Learn From Experts"/>
+         <MT N="DCSext.level4" V="Success Stories"/>
+         <MT N="DCSext.level5" V="Community Economic Development Initiatives"/>
+         <MT N="DCSext.level6" V="Mobile Produce Press"/>
+         <MT N="DCSext.level1" V="Employment, Business &amp; Economic Development"/>
+         <MT N="DCSext.level2" V="Economic Development"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Wildwood Ecoforest Success Story"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="8BB4103983EB4C7B8A21C2AD2AECB801"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="114884.0"/>
+         <MT N="level5" V="Community Economic Development Initiatives"/>
+         <MT N="level4" V="Success Stories"/>
+         <MT N="level6" V="Mobile Produce Press"/>
+         <MT N="current_page_id" V="CB3451659ECE4C4B9219D34E8099A8D4"/>
+         <MT N="level1" V="Employment Business &amp; Economic Development"/>
+         <MT N="level3" V="BC Ideas Exchange: Learn From Experts"/>
+         <MT N="level2" V="Economic Development"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_jtst"/>
+         <MT N="content_group" V="CMF_gov_jtst_maintainer"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="8EB2DD2AAE774FCB9D4D715A339904A0"/>
+         <MT N="navigaton_title" V="Mobile Produce Press"/>
+         <MT N="MBCTERMS.subjectCategory" V="Economics and Industry"/>
+         <MT N="level5_id" V="3EC2111B72784BCD9EAE419183FEE199"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Products and Local &lt;b&gt;Jobs&lt;/b&gt;
+Creston Valley
+How...of equipment create &lt;b&gt;jobs&lt;/b&gt;, generate economic opportunities...creating meaningful, local &lt;b&gt;jobs&lt;/b&gt; and fulfilling the</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="112.19k"/>
+         </HAS>
+      </R>
+      <R N="10">
+         <U>https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/community-forest-license</U>
+         <UE>https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/community-forest-license</UE>
+         <T>Creating Jobs and New Revenue Streams with a Community Forest License - Province of British Columbia</T>
+         <RK>62.31402228523098</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-06-24"/>
+         <MT N="query_id" V="60150707014856"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1593013009903"/>
+         <MT N="DCSext.creator" V="Ministry of Jobs Tourism and Skills Training"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Community development"/>
+         <MT N="DCTERMS.subject" V="Economic development"/>
+         <MT N="DCTERMS.subject" V="Rural communities"/>
+         <MT N="DCTERMS.subject" V="Best practices"/>
+         <MT N="DCTERMS.subject" V="Local governments"/>
+         <MT N="level1_id" V="820A75B4A1AF426C9450E4ADF0D1D783"/>
+         <MT N="keywords" V="Economic Development Success Story, Rebuilding Community Health, Village of Burns Lake,  Lakeside Multiplex, major employer, Babine Forest Products explosion, Northern Development Initiative Trust assisted with a grant, rural community"/>
+         <MT N="DCSext.current_page" V="Community Forest License"/>
+         <MT N="mes:date" V="1593013009000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Creating Jobs and New Revenue Streams with a Community Forest License - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="5D55B284D4A34B58B5DC1341CF976083"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="7958EA9A19784188A8A726CD8E8A6533"/>
+         <MT N="content_group_id" V="C9ECEF9A59E244C88A7BA3FFA40CF968"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2016-12-06"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/employment-business/economic-development/bc-ideas-exchange/success-stories/community-economic-development-initiatives/community-forest-license"/>
+         <MT N="DCTERMS.modified" V="2020-06-01"/>
+         <MT N="DCTERMS.creator" V="Ministry of Jobs Tourism and Skills Training"/>
+         <MT N="current_page" V="Community Forest License"/>
+         <MT N="level6_id" V="0E2D73E2E88E47E2B0F60AD3194E9E67"/>
+         <MT N="DCSext.level3" V="BC Ideas Exchange: Learn From Experts"/>
+         <MT N="DCSext.level4" V="Success Stories"/>
+         <MT N="DCSext.level5" V="Community Economic Development Initiatives"/>
+         <MT N="DCSext.level6" V="Community Forest License"/>
+         <MT N="DCSext.level1" V="Employment, Business &amp; Economic Development"/>
+         <MT N="DCSext.level2" V="Economic Development"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Community Profile Success Story"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="8BB4103983EB4C7B8A21C2AD2AECB801"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="109074.0"/>
+         <MT N="level5" V="Community Economic Development Initiatives"/>
+         <MT N="level4" V="Success Stories"/>
+         <MT N="level6" V="Community Forest License"/>
+         <MT N="current_page_id" V="0E2D73E2E88E47E2B0F60AD3194E9E67"/>
+         <MT N="level1" V="Employment Business &amp; Economic Development"/>
+         <MT N="level3" V="BC Ideas Exchange: Learn From Experts"/>
+         <MT N="level2" V="Economic Development"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_jtst"/>
+         <MT N="content_group" V="CMF_gov_jtst_maintainer"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="8EB2DD2AAE774FCB9D4D715A339904A0"/>
+         <MT N="navigaton_title" V="Community Forest License"/>
+         <MT N="MBCTERMS.subjectCategory" V="Economics and Industry"/>
+         <MT N="level5_id" V="3EC2111B72784BCD9EAE419183FEE199"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Webinar Series
+Creating &lt;b&gt;Jobs&lt;/b&gt; and New Revenue Streams...Milling and Carpentry &lt;b&gt;Job&lt;/b&gt; Creation Project, creating</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="106.52k"/>
+         </HAS>
+      </R>
+      <PARM>
+         <PC>0</PC>
+         <PMT DN="Theme" IR="0" NM="level1" T="0"><PV C="434" H="" L="" V="Careers &amp; MyHR"/><PV C="414" H="" L="" V="Data"/><PV C="371" H="" L="" V="Employment Business &amp; Economic Development"/><PV C="265" H="" L="" V="Employment business and economic development"/><PV C="262" H="" L="" V="British Columbians and our governments"/><PV C="140" H="" L="" V="British Columbians &amp; Our Governments"/><PV C="96" H="" L="" V="Careers and MyHR"/><PV C="95" H="" L="" V="Farming natural resources and industry"/><PV C="55" H="" L="" V="Law Crime &amp; Justice"/><PV C="41" H="" L="" V="Birth Adoption Death Marriage &amp; Divorce"/><PV C="31" H="" L="" V="Health"/><PV C="27" H="" L="" V="Education &amp; Training"/><PV C="26" H="" L="" V="Education and training"/><PV C="25" H="" L="" V="Environmental protection and sustainability"/><PV C="22" H="" L="" V="Family and social supports"/><PV C="19" H="" L="" V="Law crime and justice"/><PV C="16" H="" L="" V="Farming Natural Resources &amp; Industry"/><PV C="14" H="" L="" V="Taxes and tax credits"/><PV C="13" H="" L="" V="Family &amp; Social Supports"/><PV C="13" H="" L="" V="Driving &amp; Transportation"/><PV C="12" H="" L="" V="Birth adoption death marriage and divorce"/><PV C="11" H="" L="" V="Tourism &amp; Immigration"/><PV C="10" H="" L="" V="Public safety and emergency services"/><PV C="8" H="" L="" V="Driving and transportation"/><PV C="7" H="" L="" V="Sports Recreation Arts &amp; Culture"/><PV C="7" H="" L="" V="Public Safety &amp; Emergency Services"/><PV C="7" H="" L="" V="Economic recovery"/><PV C="7" H="" L="" V="COVID-19"/><PV C="6" H="" L="" V="Housing and tenancy"/><PV C="5" H="" L="" V="Tourism and immigration"/><PV C="3" H="" L="" V="Sports recreation arts and culture"/><PV C="3" H="" L="" V="Home"/><PV C="3" H="" L="" V="Gender Equity in B.C."/><PV C="3" H="" L="" V="Export Catalogue"/><PV C="1" H="" L="" V="Taxes &amp; Tax Credits"/><PV C="1" H="" L="" V="Revenue Services Transition Project"/><PV C="1" H="" L="" V="Minimum Wage Home"/><PV C="1" H="" L="" V="Kicking Horse Canyon Project"/><PV C="1" H="" L="" V="erase"/></PMT>
+      </PARM>
+   </RES>
+</GSP>

--- a/data/search/xml/msp.xml
+++ b/data/search/xml/msp.xml
@@ -1,0 +1,734 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GSP xmlns:xs="http://www.w3.org/2001/XMLSchema" VER="3.2">
+   <TM>0.519000</TM>
+   <Q>msp</Q>
+   <PARAM name="site" original_value="default_collection" value="default_collection"/>
+   <PARAM name="client" original_value="default_frontend" value="default_frontend"/>
+   <PARAM name="start" original_value="0" value="0"/>
+   <PARAM name="getfields" original_value="*" value="*"/>
+   <PARAM name="q" original_value="msp" value="msp"/>
+   <RES EN="10" SN="1">
+      <M>4420</M>
+      <FI/>
+      <NB>
+         <NU>/search?site=default_collection&amp;client=default_frontend&amp;q=msp&amp;start=10</NU>
+      </NB>
+      <R N="1">
+         <U>https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/software/conformance-standards/hni-healthnetbc-interface-business-services/e45-msp-coverage-status-check</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/software/conformance-standards/hni-healthnetbc-interface-business-services/e45-msp-coverage-status-check</UE>
+         <T>E45 - MSP Coverage Status Check - Province of British Columbia</T>
+         <RK>67.60177417627843</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2015-07-17"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1437150455000"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="E45, MSP Coverage Status Check"/>
+         <MT N="DCSext.current_page" V="E45 - MSP Coverage Status Check"/>
+         <MT N="mes:date" V="1437150455000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="E45 - MSP Coverage Status Check - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="C1DFD386AEA7460887A42B5CFF359584"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-02-02"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/software/conformance-standards/hni-healthnetbc-interface-business-services/e45-msp-coverage-status-check"/>
+         <MT N="DCTERMS.modified" V="2015-07-17"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="E45 - MSP Coverage Status Check"/>
+         <MT N="level6_id" V="626511011B29402FA311075C2C40CF75"/>
+         <MT N="DCSext.level3" V="Health Information Exchange (HIE) Systems"/>
+         <MT N="DCSext.level4" V="Conformance Standards"/>
+         <MT N="DCSext.level5" V="HNI (healthnetBC Interface) Business Services"/>
+         <MT N="DCSext.level6" V="E45 - MSP Coverage Status Check"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Practitioner &amp; Professional Resources"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="E45 - MSP Coverage Status Check"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="C277B204292E44EEBAD4B0FB48C8A0AA"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="99849.0"/>
+         <MT N="level5" V="HNI (healthnetBC Interface) Business Services"/>
+         <MT N="level4" V="Conformance Standards"/>
+         <MT N="level6" V="E45 - MSP Coverage Status Check"/>
+         <MT N="current_page_id" V="626511011B29402FA311075C2C40CF75"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="Health Information Exchange (HIE) Systems"/>
+         <MT N="level2" V="Practitioner &amp; Professional Resources"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="level4_id" V="4452530C7709410C831B3842A3B1221D"/>
+         <MT N="navigaton_title" V="E45 - MSP Coverage Status Check"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="level5_id" V="F1D0EF16DFEF4E5C92C2037B4524E51B"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Forms
+FAQ
+E45 - &lt;b&gt;MSP&lt;/b&gt; Coverage Status Check...also checks the &lt;b&gt;MSP&lt;/b&gt; Claims Pre-authorization file</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="97.51k"/>
+         </HAS>
+      </R>
+      <R N="2">
+         <U>https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp</U>
+         <UE>https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp</UE>
+         <T>Medical Services Plan (MSP) - Province of British Columbia</T>
+         <RK>65.25052333540559</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2018-12-18"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1545166174000"/>
+         <MT N="DCSext.creator" V="BC Public Service Agency"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Benefits"/>
+         <MT N="level1_id" V="C6D1F618844441778AD409A9C99C1CD3"/>
+         <MT N="keywords" V="eligibility"/>
+         <MT N="DCSext.current_page" V="Medical Services Plan (MSP)"/>
+         <MT N="mes:date" V="1545166174000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan (MSP) - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="015013A6A838410593D05F257E80CDCF"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2016-02-25"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp"/>
+         <MT N="DCTERMS.modified" V="2018-12-18"/>
+         <MT N="DCTERMS.creator" V="BC Public Service Agency"/>
+         <MT N="bcpsa_subjects" V="Employee benefits"/>
+         <MT N="bcpsa_subjects" V="Health"/>
+         <MT N="bcpsa_enhancedSearch" V="myhr"/>
+         <MT N="current_page" V="Medical Services Plan (MSP)"/>
+         <MT N="DCSext.level3" V="Pay &amp; Benefits"/>
+         <MT N="DCSext.level4" V="Employee Benefits"/>
+         <MT N="DCSext.level5" V="Medical Services Plan (MSP)"/>
+         <MT N="DCSext.level1" V="Careers &amp; MyHR"/>
+         <MT N="DCSext.level2" V="All Employees"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Information on both included and excluded benefits eligibility."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="1B7D1F2DB611456C8A475583D93CD94C"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="99729.0"/>
+         <MT N="level5" V="Medical Services Plan (MSP)"/>
+         <MT N="level4" V="Employee Benefits"/>
+         <MT N="current_page_id" V="EFAF2399E3F04F52A4D204C527BF855E"/>
+         <MT N="level1" V="Careers &amp; MyHR"/>
+         <MT N="level3" V="Pay &amp; Benefits"/>
+         <MT N="level2" V="All Employees"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="CA745CED83314A7D9B54FA4E202F362C"/>
+         <MT N="navigaton_title" V="Medical Services Plan (MSP)"/>
+         <MT N="MBCTERMS.subjectCategory" V="Labour"/>
+         <MT N="level5_id" V="EFAF2399E3F04F52A4D204C527BF855E"/>
+         <MT N="DCTERMS.audience" V="Provincial Government"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Your Personal Information
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;)
+This content has...your bookmarks.
+For &lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) information for BC</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="97.39k"/>
+         </HAS>
+      </R>
+      <R N="3">
+         <U>https://www2.gov.bc.ca/gov/content/health/health-forms/msp</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/health-forms/msp</UE>
+         <T>Medical Services Plan (MSP) Forms - Province of British Columbia</T>
+         <RK>62.488272347547664</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2019-10-29"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1572369145000"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="Medical Services Plan (MSP) Forms, Forms for B.C. Residents, Forms for Group Plan Administrators, Forms for Medical &amp; Health Care Practitioners, Advisory Committee on Diagnostic Services Forms"/>
+         <MT N="DCSext.current_page" V="MSP"/>
+         <MT N="mes:date" V="1572369145000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan (MSP) Forms - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="D8D2E52B3ABB41289B1D3EBA5B8C21F1"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-02-17"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/health-forms/msp"/>
+         <MT N="DCTERMS.modified" V="2019-10-29"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="MSP"/>
+         <MT N="DCSext.level3" V="MSP"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Health Forms"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Medical Services Plan (MSP) Forms"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="AEA02CD7BBE44DA58CA249421CEC24DE"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="97983.0"/>
+         <MT N="current_page_id" V="AEA02CD7BBE44DA58CA249421CEC24DE"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="MSP"/>
+         <MT N="level2" V="Health Forms"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="navigaton_title" V="MSP"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Group Plan Administrators
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) Forms
+Some web...</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="95.69k"/>
+         </HAS>
+      </R>
+      <R N="4">
+         <U>https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/service-design/case-studies/transforming-the-medical-services-plan</U>
+         <UE>https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/service-design/case-studies/transforming-the-medical-services-plan</UE>
+         <T>Making it easier to sign up for health insurance: Transforming the Medical Services Plan - Province of British Columbia</T>
+         <RK>56.44102018488175</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2021-01-06"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1609909518949"/>
+         <MT N="DCSext.creator" V="Government Communications and Public Engagement"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Government communications"/>
+         <MT N="DCTERMS.subject" V="Consumer experience"/>
+         <MT N="DCTERMS.subject" V="Government information"/>
+         <MT N="DCTERMS.subject" V="Design"/>
+         <MT N="level1_id" V="1BCDDAA9ED30487784F29ADC800E5DCB"/>
+         <MT N="keywords" V="Service Design, MSP, health insurance, digital product"/>
+         <MT N="DCSext.current_page" V="Transforming the Medical Services Plan"/>
+         <MT N="mes:date" V="1609909518000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Making it easier to sign up for health insurance: Transforming the Medical Services Plan - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="D8E5FDC8B04A13F8D1E77F8D52EE563A"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="BA55B793DD05427AB4936C62799E760E"/>
+         <MT N="content_group_id" V="DBD1CAF9701F426A8D24B505F2D379D7"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2018-10-10"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/service-design/case-studies/transforming-the-medical-services-plan"/>
+         <MT N="DCTERMS.modified" V="2021-01-05"/>
+         <MT N="DCTERMS.creator" V="Government Communications and Public Engagement"/>
+         <MT N="current_page" V="Transforming the Medical Services Plan"/>
+         <MT N="level6_id" V="4FC39F3DCBFF490E90B8773943936875"/>
+         <MT N="DCSext.level3" V="Service Experience &amp; Digital Delivery"/>
+         <MT N="DCSext.level4" V="Service Design"/>
+         <MT N="DCSext.level5" V="Case Studies"/>
+         <MT N="DCSext.level6" V="Transforming the Medical Services Plan"/>
+         <MT N="DCSext.level1" V="British Columbians and our governments"/>
+         <MT N="DCSext.level2" V="Services &amp; policies for government"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="To improve the enrolment and Premium Assistance application process, the Ministry of Health wanted to introduce a digital self-serve product, an online enrollment form."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="D960EA80125447EC8FE61A53B3922182"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="110926.0"/>
+         <MT N="level5" V="Case Studies"/>
+         <MT N="level4" V="Service Design"/>
+         <MT N="level6" V="Transforming the Medical Services Plan"/>
+         <MT N="current_page_id" V="4FC39F3DCBFF490E90B8773943936875"/>
+         <MT N="level1" V="British Columbians and our governments"/>
+         <MT N="level3" V="Service Experience &amp; Digital Delivery"/>
+         <MT N="level2" V="Services &amp; policies for government"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_servicedesign_ext"/>
+         <MT N="content_group" V="CMF_gov_services_policies_gov_approver"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="4FB03369094247EF850BEFF8EFB201B3"/>
+         <MT N="navigaton_title" V="Transforming the Medical Services Plan"/>
+         <MT N="MBCTERMS.subjectCategory" V="Education and Training"/>
+         <MT N="MBCTERMS.subjectCategory" V="Information and Communications"/>
+         <MT N="level5_id" V="212AF46AC0724BA5BD07A0FC62EE8338"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>sign up for &lt;b&gt;health insurance&lt;/b&gt;: Transforming the &lt;b&gt;Medical Services Plan&lt;/b&gt;
+Context and questions
+The &lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) is British Columbia’s public &lt;b&gt;health insurance&lt;/b&gt;. It covers the...</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="108.33k"/>
+         </HAS>
+      </R>
+      <R N="5">
+         <U>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/msp-account-change-faqs</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/msp-account-change-faqs</UE>
+         <T>Medical Services Plan (MSP) Account Change FAQs - Province of British Columbia</T>
+         <RK>53.762769227064574</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-07-06"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1594060524123"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health insurance"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="MSP Account Change Frequently Asked Questions, Medical Services Plan , FAQ"/>
+         <MT N="DCSext.current_page" V="Medical Services Plan (MSP) Account Change FAQs"/>
+         <MT N="mes:date" V="1594060524000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan (MSP) Account Change FAQs - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="7A3AF3683BCA48BEB6717B3B93EE6A0A"/>
+         <MT N="content_group_id" V="85A6C31BB51F4DF4932EE92D0533E250"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="5061105D82B44312BB31780BA6F12984"/>
+         <MT N="content_group_id" V="97CA0E9AFC8847058CDA4936FA91E955"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2017-11-24"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/msp-account-change-faqs"/>
+         <MT N="DCTERMS.modified" V="2020-07-06"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="Medical Services Plan (MSP) Account Change FAQs"/>
+         <MT N="level6_id" V="2D04B83866B04BD190BC81F019EE45F2"/>
+         <MT N="DCSext.level3" V="Medical Services Plan"/>
+         <MT N="DCSext.level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="DCSext.level5" V="Managing Your MSP Account"/>
+         <MT N="DCSext.level6" V="Medical Services Plan (MSP) Account Change FAQs"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Health &amp; Drug Coverage"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="MSP Account Change Request Online Form  Frequently Asked Questions"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="91C51D566CF941BAA404E4C5657399EA"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="122434.0"/>
+         <MT N="level5" V="Managing Your MSP Account"/>
+         <MT N="level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="level6" V="Medical Services Plan (MSP) Account Change FAQs"/>
+         <MT N="current_page_id" V="2D04B83866B04BD190BC81F019EE45F2"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="Medical Services Plan"/>
+         <MT N="level2" V="Health &amp; Drug Coverage"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_health"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_finance"/>
+         <MT N="content_group" V="CMF_gov_health_access_health"/>
+         <MT N="CMF_ContentType" V="General Content"/>
+         <MT N="level4_id" V="239FC60D45274CA59FCDF001A2F89899"/>
+         <MT N="navigaton_title" V="Medical Services Plan (MSP) Account Change FAQs"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="level5_id" V="5FDD0B887BDC4D38925467A7462AADD6"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Health &amp;amp; Drug Coverage &lt;b&gt;Medical Services Plan Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Residents Managing Your &lt;b&gt;MSP&lt;/b&gt; Account
+     		Section Navigation
+
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) for British Columbia</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="119.56k"/>
+         </HAS>
+      </R>
+      <R N="6">
+         <U>https://www2.gov.bc.ca/gov/content/family-social-supports/seniors/health-safety/health-care-programs-and-services/medical-services-plan-msp</U>
+         <UE>https://www2.gov.bc.ca/gov/content/family-social-supports/seniors/health-safety/health-care-programs-and-services/medical-services-plan-msp</UE>
+         <T>Medical Services Plan (MSP) - Province of British Columbia</T>
+         <RK>52.40676874212101</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-01-27"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1580148795000"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Seniors"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="DCTERMS.subject" V="Health care"/>
+         <MT N="level1_id" V="FD488413D1B74C5B931B2F6B0E00C61D"/>
+         <MT N="keywords" V="Medical Services Plan, MSP, Medical Services Plan (MSP), MSP Premiums, MSP Premium Assistance, MSP forms, premiums"/>
+         <MT N="DCSext.current_page" V="Medical Services Plan (MSP)"/>
+         <MT N="mes:date" V="1580148795000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan (MSP) - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="9671EB5EBAC740A496EC12DBE67B4426"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="680D837E9E5A400FAA29F888AF71AE00"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2012-09-12"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/family-social-supports/seniors/health-safety/health-care-programs-and-services/medical-services-plan-msp"/>
+         <MT N="DCTERMS.modified" V="2020-01-27"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="Medical Services Plan (MSP)"/>
+         <MT N="DCSext.level3" V="Health &amp; Safety"/>
+         <MT N="DCSext.level4" V="Health Care Programs and Services"/>
+         <MT N="DCSext.level5" V="Medical Services Plan (MSP)"/>
+         <MT N="DCSext.level1" V="Family &amp; Social Supports"/>
+         <MT N="DCSext.level2" V="Seniors"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Medical Services Plan (MSP)"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="C163331A938A48E386AF450BE8E283FF"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="107695.0"/>
+         <MT N="level5" V="Medical Services Plan (MSP)"/>
+         <MT N="level4" V="Health Care Programs and Services"/>
+         <MT N="current_page_id" V="19F39621B1324977813579CE82F3D08F"/>
+         <MT N="level1" V="Family &amp; Social Supports"/>
+         <MT N="level3" V="Health &amp; Safety"/>
+         <MT N="level2" V="Seniors"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_seniorsbc"/>
+         <MT N="WT.cg_s" V="19F39621B1324977813579CE82F3D08F"/>
+         <MT N="WT.cg_n" V="Family &amp; Social Supports;Seniors"/>
+         <MT N="level4_id" V="BA3DC5FDEC874BBABD2C6C354BEFA7A7"/>
+         <MT N="navigaton_title" V="Medical Services Plan (MSP)"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="level5_id" V="19F39621B1324977813579CE82F3D08F"/>
+         <MT N="DCTERMS.audience" V="General Public"/>
+         <MT N="DCTERMS.audience" V="Seniors"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>and Disaster Preparedness
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;)
+British Columbia's &lt;b&gt;Medical Services Plan&lt;/b&gt; is a &lt;b&gt;health insurance&lt;/b&gt; plan that pays...</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="105.17k"/>
+         </HAS>
+      </R>
+      <R N="7">
+         <U>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents</UE>
+         <T>Medical Services Plan (MSP) for British Columbia (B.C.) Residents - Province of British Columbia</T>
+         <RK>51.5882684494025</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-03-31"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1585669825884"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="B.C. Residents, Eligibility and Enrolment, Benefits, Premiums, Personal Health Identification, Managing your MSP Account, Contact Us"/>
+         <MT N="DCSext.current_page" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="mes:date" V="1585669825000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="7A3AF3683BCA48BEB6717B3B93EE6A0A"/>
+         <MT N="content_group_id" V="85A6C31BB51F4DF4932EE92D0533E250"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="5061105D82B44312BB31780BA6F12984"/>
+         <MT N="content_group_id" V="0B851B2CC5B14EFE8958C45C37BE1CF5"/>
+         <MT N="content_group_id" V="97CA0E9AFC8847058CDA4936FA91E955"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-01-08"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents"/>
+         <MT N="DCTERMS.modified" V="2020-03-31"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="DCSext.level3" V="Medical Services Plan"/>
+         <MT N="DCSext.level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Health &amp; Drug Coverage"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Medical Services Plan for B.C. Residents"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="91C51D566CF941BAA404E4C5657399EA"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="110696.0"/>
+         <MT N="level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="current_page_id" V="239FC60D45274CA59FCDF001A2F89899"/>
+         <MT N="ese_enhancedSearch" V="povertySupports"/>
+         <MT N="ese_enhancedSearch" V="services"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="Medical Services Plan"/>
+         <MT N="level2" V="Health &amp; Drug Coverage"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_health"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_finance"/>
+         <MT N="content_group" V="CMF_gov_sdsi"/>
+         <MT N="content_group" V="CMF_gov_health_access_health"/>
+         <MT N="level4_id" V="239FC60D45274CA59FCDF001A2F89899"/>
+         <MT N="navigaton_title" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Health &amp;amp; Drug Coverage &lt;b&gt;Medical Services Plan&lt;/b&gt;
+     		Section Navigation
+
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Identification
+Managing Your &lt;b&gt;MSP&lt;/b&gt; Account
+&lt;b&gt;MSP&lt;/b&gt; Premium Elimination: Jan. 1, 2020
+&lt;b&gt;Medical Services Plan&lt;/b&gt; – British Columbia...Administrators - Contact Us
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...your account or &lt;b&gt;MSP&lt;/b&gt; benefits, please contact &lt;b&gt;Health Insurance&lt;/b&gt; BC.
+Contact Us</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="108.1k"/>
+         </HAS>
+      </R>
+      <R N="8">
+         <U>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/benefits/services-not-covered-by-msp</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/benefits/services-not-covered-by-msp</UE>
+         <T>Services Not Covered by the Medical Services Plan (MSP) - Province of British Columbia</T>
+         <RK>51.25926833174288</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-01-22"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1579718933000"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="Services Not Covered by MSP"/>
+         <MT N="DCSext.current_page" V="Services Not Covered by the Medical Services Plan (MSP)"/>
+         <MT N="mes:date" V="1579718933000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Services Not Covered by the Medical Services Plan (MSP) - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="7A3AF3683BCA48BEB6717B3B93EE6A0A"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="85A6C31BB51F4DF4932EE92D0533E250"/>
+         <MT N="content_group_id" V="5061105D82B44312BB31780BA6F12984"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-01-08"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/benefits/services-not-covered-by-msp"/>
+         <MT N="DCTERMS.modified" V="2020-01-22"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="Services Not Covered by the Medical Services Plan (MSP)"/>
+         <MT N="level6_id" V="D6E927C96F944FF79832721FF5E1B928"/>
+         <MT N="DCSext.level3" V="Medical Services Plan"/>
+         <MT N="DCSext.level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="DCSext.level5" V="Benefits"/>
+         <MT N="DCSext.level6" V="Services Not Covered by the Medical Services Plan (MSP)"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Health &amp; Drug Coverage"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Services Not Covered by MSP."/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="91C51D566CF941BAA404E4C5657399EA"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="104612.0"/>
+         <MT N="level5" V="Benefits"/>
+         <MT N="level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="level6" V="Services Not Covered by the Medical Services Plan (MSP)"/>
+         <MT N="current_page_id" V="D6E927C96F944FF79832721FF5E1B928"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="Medical Services Plan"/>
+         <MT N="level2" V="Health &amp; Drug Coverage"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_health"/>
+         <MT N="content_group" V="CMF_gov_finance"/>
+         <MT N="WT.cg_s" V="D6E927C96F944FF79832721FF5E1B928"/>
+         <MT N="WT.cg_n" V="Health;Health &amp; Drug Coverage"/>
+         <MT N="level4_id" V="239FC60D45274CA59FCDF001A2F89899"/>
+         <MT N="navigaton_title" V="Services Not Covered by the Medical Services Plan (MSP)"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="level5_id" V="623403A1678342308F8AD154F73FE06A"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Health &amp;amp; Drug Coverage &lt;b&gt;Medical Services Plan Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Benefits
+     		Section Navigation
+
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Services Covered by &lt;b&gt;MSP&lt;/b&gt;
+Services Not Covered by the &lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;)
+Additional Fees and...Covered by the &lt;b&gt;Medical Services Plan (MSP)
+MSP&lt;/b&gt; does not provide...are covered by &lt;b&gt;MSP&lt;/b&gt;, contact &lt;b&gt;Health Insurance&lt;/b&gt; BC for more</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="102.16k"/>
+         </HAS>
+      </R>
+      <R N="9">
+         <U>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/opting-out-of-msp-coverage</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/opting-out-of-msp-coverage</UE>
+         <T>Opting Out of Medical Services Plan (MSP) Coverage - Province of British Columbia</T>
+         <RK>50.984018233305775</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2019-12-31"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1577830838000"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="Opting Out of MSP Coverage, Consequences of Opting Out, Important Information"/>
+         <MT N="DCSext.current_page" V="Opting Out of Medical Services Plan (MSP) Coverage"/>
+         <MT N="mes:date" V="1577830838000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Opting Out of Medical Services Plan (MSP) Coverage - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="7A3AF3683BCA48BEB6717B3B93EE6A0A"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="85A6C31BB51F4DF4932EE92D0533E250"/>
+         <MT N="content_group_id" V="5061105D82B44312BB31780BA6F12984"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-01-08"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents/managing-your-msp-account/opting-out-of-msp-coverage"/>
+         <MT N="DCTERMS.modified" V="2019-12-31"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="Opting Out of Medical Services Plan (MSP) Coverage"/>
+         <MT N="level6_id" V="F0F04CFE72EB4508B175A5B2A4B64184"/>
+         <MT N="DCSext.level3" V="Medical Services Plan"/>
+         <MT N="DCSext.level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="DCSext.level5" V="Managing Your MSP Account"/>
+         <MT N="DCSext.level6" V="Opting Out of Medical Services Plan (MSP) Coverage"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Health &amp; Drug Coverage"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Opting Out of MSP Coverage"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="91C51D566CF941BAA404E4C5657399EA"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="109234.0"/>
+         <MT N="level5" V="Managing Your MSP Account"/>
+         <MT N="level4" V="Medical Services Plan (MSP) for British Columbia (B.C.) Residents"/>
+         <MT N="level6" V="Opting Out of Medical Services Plan (MSP) Coverage"/>
+         <MT N="current_page_id" V="F0F04CFE72EB4508B175A5B2A4B64184"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="Medical Services Plan"/>
+         <MT N="level2" V="Health &amp; Drug Coverage"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_health"/>
+         <MT N="content_group" V="CMF_gov_finance"/>
+         <MT N="WT.cg_s" V="F0F04CFE72EB4508B175A5B2A4B64184"/>
+         <MT N="WT.cg_n" V="Health;Health &amp; Drug Coverage"/>
+         <MT N="level4_id" V="239FC60D45274CA59FCDF001A2F89899"/>
+         <MT N="navigaton_title" V="Opting Out of Medical Services Plan (MSP) Coverage"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="level5_id" V="5FDD0B887BDC4D38925467A7462AADD6"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>Health &amp;amp; Drug Coverage &lt;b&gt;Medical Services Plan Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Residents Managing Your &lt;b&gt;MSP&lt;/b&gt; Account
+     		Section Navigation
+
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) for British Columbia...Opting Out of &lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) Coverage
+Appealing a Decision
+&lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) Account Change FAQs
+&lt;b&gt;MSP&lt;/b&gt; Premium Elimination: Jan</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="106.67k"/>
+         </HAS>
+      </R>
+      <R N="10">
+         <U>https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/msp</U>
+         <UE>https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/msp</UE>
+         <T>Medical Services Plan - Province of British Columbia</T>
+         <RK>49.7417677890424</RK>
+         <ENT_SOURCE/>
+         <FS NAME="date" VALUE="2020-12-31"/>
+         <MT N="query_id" V="79708305376441"/>
+         <MT N="prev_query_id" V=""/>
+         <MT N="datasource/modificationDate" V="1609401927301"/>
+         <MT N="DCSext.creator" V="Ministry of Health"/>
+         <MT N="security_classification" V="Low"/>
+         <MT N="datasource/category" V="Web"/>
+         <MT N="DCTERMS.subject" V="Health"/>
+         <MT N="level1_id" V="EC75FD2ECA044D2C9CCB32361905348A"/>
+         <MT N="keywords" V="Medical Services Plan, Practitioner-Specific Information, Claim Submission &amp; Payment, Opting Out of MSP, Referrals for Services Outside of Canada, Notification Service, Contact Us"/>
+         <MT N="DCSext.current_page" V="MSP"/>
+         <MT N="mes:date" V="1609401927000"/>
+         <MT N="DCTERMS.publisher" V="Province of British Columbia"/>
+         <MT N="title" V="Medical Services Plan - Province of British Columbia"/>
+         <MT N="content" V=""/>
+         <MT N="Content-Type" V="text/html; charset=UTF-8"/>
+         <MT N="level2_id" V="C1DFD386AEA7460887A42B5CFF359584"/>
+         <MT N="content_group_id" V="A23A6FFB4CD14778B5737BD4BCBB7656"/>
+         <MT N="content_group_id" V="85A6C31BB51F4DF4932EE92D0533E250"/>
+         <MT N="content_group_id" V="97CA0E9AFC8847058CDA4936FA91E955"/>
+         <MT N="datasource/fqcategory" V="Web:mb_gov_feed"/>
+         <MT N="DCTERMS.created" V="2015-01-06"/>
+         <MT N="datasource/mes:key" V="https://www2.gov.bc.ca/gov/content/health/practitioner-professional-resources/msp"/>
+         <MT N="DCTERMS.modified" V="2020-12-15"/>
+         <MT N="DCTERMS.creator" V="Ministry of Health"/>
+         <MT N="current_page" V="MSP"/>
+         <MT N="DCSext.level3" V="MSP"/>
+         <MT N="DCSext.level1" V="Health"/>
+         <MT N="DCSext.level2" V="Practitioner &amp; Professional Resources"/>
+         <MT N="datasource/categoryinstance" V="mb_gov_feed"/>
+         <MT N="description" V="Medical Services Plan"/>
+         <MT N="DCTERMS.language" V="eng"/>
+         <MT N="level3_id" V="45D23A7B0BF44CE4A3BD6BBED9500491"/>
+         <MT N="collections" V="mb_gov_feed"/>
+         <MT N="mes:size" V="112830.0"/>
+         <MT N="current_page_id" V="45D23A7B0BF44CE4A3BD6BBED9500491"/>
+         <MT N="level1" V="Health"/>
+         <MT N="level3" V="MSP"/>
+         <MT N="level2" V="Practitioner &amp; Professional Resources"/>
+         <MT N="extension" V="html"/>
+         <MT N="security_label" V="Public "/>
+         <MT N="categoryclass" V="default"/>
+         <MT N="content_group" V="CMF_gov_digital_services"/>
+         <MT N="content_group" V="CMF_gov_health"/>
+         <MT N="content_group" V="CMF_gov_health_access_health"/>
+         <MT N="navigaton_title" V="MSP"/>
+         <MT N="MBCTERMS.subjectCategory" V="Health and Safety"/>
+         <MT N="DCTERMS:interactiveResource" V="Topic"/>
+         <S>services to the &lt;b&gt;Medical Services Plan (MSP&lt;/b&gt;) and the Medical...</S>
+         <LANG/>
+         <HAS>
+            <L/>
+            <C CID="" ENC="" SZ="110.19k"/>
+         </HAS>
+      </R>
+      <PARM>
+         <PC>0</PC>
+         <PMT DN="Theme" IR="0" NM="level1" T="0"><PV C="368" H="" L="" V="Health"/><PV C="131" H="" L="" V="British Columbians and our governments"/><PV C="17" H="" L="" V="Family &amp; Social Supports"/><PV C="10" H="" L="" V="British Columbians &amp; Our Governments"/><PV C="9" H="" L="" V="Farming natural resources and industry"/><PV C="9" H="" L="" V="Careers and MyHR"/><PV C="7" H="" L="" V="Taxes and tax credits"/><PV C="6" H="" L="" V="COVID-19"/><PV C="6" H="" L="" V="Careers &amp; MyHR"/><PV C="5" H="" L="" V="Family and social supports"/><PV C="3" H="" L="" V="Driving and transportation"/><PV C="3" H="" L="" V="Birth adoption death marriage and divorce"/><PV C="2" H="" L="" V="Tourism &amp; Immigration"/><PV C="2" H="" L="" V="Taxes &amp; Tax Credits"/><PV C="2" H="" L="" V="Revenue Services Transition Project"/><PV C="2" H="" L="" V="Mental Health and Substance Use Supports in BC"/><PV C="2" H="" L="" V="Law Crime &amp; Justice"/><PV C="2" H="" L="" V="Home"/><PV C="2" H="" L="" V="Data"/><PV C="2" H="" L="" V="Birth Adoption Death Marriage &amp; Divorce"/><PV C="1" H="" L="" V="Housing and tenancy"/><PV C="1" H="" L="" V="Gender Equity in B.C."/><PV C="1" H="" L="" V="Environmental protection and sustainability"/><PV C="1" H="" L="" V="Employment business and economic development"/><PV C="1" H="" L="" V="Employment Business &amp; Economic Development"/><PV C="1" H="" L="" V="Education &amp; Training"/><PV C="1" H="" L="" V="Economic recovery"/></PMT>
+      </PARM>
+   </RES>
+</GSP>

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1",
       "dependencies": {
         "@bcgov/bc-sans": "1.0.1",
+        "axios": "^0.21.1",
         "core-js": "3.9.1",
         "dompurify": "2.2.7",
         "node-sass": "5.0.0",
@@ -21,7 +22,8 @@
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
         "react-tooltip": "4.2.17",
-        "styled-components": "5.2.1"
+        "styled-components": "5.2.1",
+        "xml2js": "^0.4.23"
       },
       "devDependencies": {
         "@babel/core": "7.13.10",
@@ -4106,6 +4108,14 @@
       "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/axobject-query": {
@@ -23607,6 +23617,26 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -26889,6 +26919,14 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
       "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ=="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -42060,6 +42098,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",
+    "axios": "^0.21.1",
     "core-js": "3.9.1",
     "dompurify": "2.2.7",
     "node-sass": "5.0.0",
@@ -16,7 +17,8 @@
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "react-tooltip": "4.2.17",
-    "styled-components": "5.2.1"
+    "styled-components": "5.2.1",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@babel/core": "7.13.10",

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -7,6 +7,7 @@ import "./App.scss";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Logout from "./pages/Logout";
+import Search from "./pages/Search";
 import Services from "./pages/Services";
 import Themes from "./pages/Themes";
 import News from "./pages/News";
@@ -78,6 +79,12 @@ function App() {
         title={""}
         breadcrumbs={[]}
         content={<Home />}
+      />
+      <PrivateRoute
+        path={"/search"}
+        title={""}
+        breadcrumbs={[]}
+        content={<Search />}
       />
       <PrivateRoute
         path={"/services"}

--- a/react-app/src/components/LoadSpinner.js
+++ b/react-app/src/components/LoadSpinner.js
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "styled-components";
+
+const LoadSpinnerContainer = styled.div`
+  // From https://github.com/lukehaas/css-loaders/blob/step2/css/load7.css
+  .loader,
+  .loader:before,
+  .loader:after {
+    border-radius: 50%;
+    width: 2.5em;
+    height: 2.5em;
+    -webkit-animation-fill-mode: both;
+    animation-fill-mode: both;
+    -webkit-animation: pulse 1.2s infinite ease-in-out;
+    animation: pulse 1.2s infinite ease-in-out;
+  }
+  .loader {
+    color: #d6d6d6;
+    font-size: 10px;
+    margin: 20px auto 70px auto;
+    position: relative;
+    -webkit-animation-delay: -0.12s;
+    animation-delay: -0.12s;
+  }
+  .loader:before,
+  .loader:after {
+    content: "";
+    position: absolute;
+    top: 0;
+  }
+  .loader:before {
+    left: -3.5em;
+    -webkit-animation-delay: -0.24s;
+    animation-delay: -0.24s;
+  }
+  .loader:after {
+    left: 3.5em;
+  }
+  @-webkit-keyframes pulse {
+    0%,
+    80%,
+    100% {
+      box-shadow: 0 2.5em 0 -1.3em;
+    }
+    40% {
+      box-shadow: 0 2.5em 0 0;
+    }
+  }
+  @keyframes pulse {
+    0%,
+    80%,
+    100% {
+      box-shadow: 0 2.5em 0 -1.3em;
+    }
+    40% {
+      box-shadow: 0 2.5em 0 0;
+    }
+  }
+`;
+
+function LoadSpinner() {
+  return (
+    <LoadSpinnerContainer>
+      <div className="loader" />
+    </LoadSpinnerContainer>
+  );
+}
+
+export default LoadSpinner;

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -26,11 +26,11 @@ const SearchForm = styled.div`
     background: none;
     border: 0;
     display: inline-block;
+    flex-grow: 1;
     font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
     font-size: 18px;
     padding: 10px;
     vertical-align: middle;
-    width: 872px;
 
     :focus {
       outline: 4px solid #3b99fc;
@@ -42,6 +42,7 @@ const SearchButton = styled.button`
   background: none;
   border: none;
   box-sizing: border-box;
+  cursor: pointer;
   display: inline-block;
   height: 44px;
   min-width: 44px;
@@ -54,9 +55,19 @@ const SearchButton = styled.button`
     height: 24px;
     width: 24px;
   }
+
+  &:disabled,
+  [disabled] {
+    cursor: not-allowed;
+  }
 `;
 
-function SearchBar({ initialInput = "", parentCallback, placeHolder }) {
+function SearchBar({
+  initialInput = "",
+  onButtonClick,
+  parentCallback,
+  placeHolder,
+}) {
   const [inputValue, setInputValue] = useState(initialInput || "");
 
   function onChangeHandler(event) {
@@ -77,7 +88,8 @@ function SearchBar({ initialInput = "", parentCallback, placeHolder }) {
           placeholder={placeHolder}
         />
         <SearchButton
-          disabled={true} // For now, all search buttons are just decorative
+          disabled={onButtonClick ? false : true} // Disable if no onClick is provided
+          onClick={onButtonClick}
         >
           <SearchIcon />
         </SearchButton>

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -50,14 +50,14 @@ const SearchButton = styled.button`
   width: 44px;
 
   svg {
-    color: #888888;
+    color: #313132;
     height: 24px;
     width: 24px;
   }
 `;
 
-function SearchBar({ parentCallback, placeHolder }) {
-  const [inputValue, setInputValue] = useState("");
+function SearchBar({ initialInput = "", parentCallback, placeHolder }) {
+  const [inputValue, setInputValue] = useState(initialInput || "");
 
   function onChangeHandler(event) {
     setInputValue(event.target.value);

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -1,7 +1,11 @@
-import React from "react";
-import { useLocation } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { Helmet } from "react-helmet";
+import { useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components";
+import xml2js from "xml2js";
 
+import LoadSpinner from "../../components/LoadSpinner";
 import SearchBar from "../../components/SearchBar";
 
 const StyledSearchResults = styled.main`
@@ -19,15 +23,107 @@ function useQuery() {
 }
 
 function Search() {
-  // Look for query parameter in the form `?q=example`
-  const query = useQuery().get("q");
+  const [state, setState] = useState({
+    query: useQuery().get("q"), // Query parameter is in the form `?q=example`
+    isLoading: useQuery().get("q") ? true : false,
+    results: {},
+    newQuery: useQuery().get("q"),
+  });
+
+  let history = useHistory();
+
+  // Callback provided to SearchBar to update state with text field input
+  function updateNewQuery(input) {
+    setState({
+      ...state,
+      newQuery: input,
+    });
+  }
+
+  // Callback provided to SearchBar to conduct a new search
+  function submitNewQuery(event) {
+    event.preventDefault();
+    history.push(`/search?q=${state.newQuery}`);
+    setState({
+      query: state?.newQuery,
+      isLoading: state?.newQuery ? true : false,
+      results: {},
+      newQuery: state?.newQuery,
+    });
+  }
+
+  useEffect(() => {
+    // GET request to the search API using the query
+    axios.get(`/api/search?q=${state?.query}`).then((res) => {
+      // Parse XML response into JSON object
+      let parser = new xml2js.Parser();
+      parser.parseString(res?.data, (err, results) => {
+        if (err) {
+          setState({
+            ...state,
+            isLoading: false,
+          });
+        } else {
+          setState({
+            ...state,
+            isLoading: false,
+            results: results,
+          });
+        }
+      });
+    });
+  }, [state.query]);
 
   return (
     <StyledSearchResults>
-      <h1>
-        Search results for <strong>"{query}"</strong>
-      </h1>
-      <SearchBar initialInput={query} />
+      {/* Page metadata */}
+      <Helmet>
+        <title>
+          {state?.query?.length > 0
+            ? `Search results for "${state?.query}"`
+            : "Search"}
+        </title>
+        <meta
+          name={"description"}
+          content={
+            state?.query?.length > 0
+              ? `Search results for "${state?.query}"`
+              : `Search gov.bc.ca`
+          }
+        />
+      </Helmet>
+
+      {state?.query?.length > 0 ? (
+        <h1>
+          Search results for <strong>{`"${state.query}"`}</strong>
+        </h1>
+      ) : (
+        <h1>Search</h1>
+      )}
+      <SearchBar
+        initialInput={state?.query}
+        onButtonClick={(event) => {
+          submitNewQuery(event);
+        }}
+        parentCallback={updateNewQuery}
+      />
+
+      {/* Show a load spinner until the API request is completed */}
+      {state?.isLoading && <LoadSpinner />}
+
+      {/* Show a list of results or a message explaining there are no results */}
+      {state?.results &&
+      Object.keys(state?.results).length > 0 &&
+      state?.results?.GSP?.RES ? (
+        state?.results?.GSP?.RES[0]?.R?.map((result) => {
+          return <p>{result.T}</p>;
+        })
+      ) : (
+        <p>
+          Your search - <strong>{state.query}</strong> - did not match any
+          documents.
+        </p>
+      )}
     </StyledSearchResults>
   );
 }

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+
+import SearchBar from "../../components/SearchBar";
+
+const StyledSearchResults = styled.main`
+  h1 {
+    font-size: 36px;
+    font-weight: 400;
+  }
+`;
+
+// Use the URLSearchParams API to parse the the query string
+// TODO: Needs to be polyfilled for IE:
+// https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#browser_compatibility
+function useQuery() {
+  return new URLSearchParams(useLocation().search);
+}
+
+function Search() {
+  // Look for query parameter in the form `?q=example`
+  const query = useQuery().get("q");
+
+  return (
+    <StyledSearchResults>
+      <h1>
+        Search results for <strong>"{query}"</strong>
+      </h1>
+      <SearchBar initialInput={query} />
+    </StyledSearchResults>
+  );
+}
+
+export default Search;

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const app = express();
 const path = require('path');
+const fs = require('fs/promises');
 const bodyParser = require('body-parser');
 const servicesData = require('./services.json');
 const PORT = process.env.PORT || 8080;
@@ -24,6 +25,39 @@ app.use(bodyParser.json());
 // API route to serve Services data to React client
 app.get('/api/services', function(req, res) {
   res.json(servicesData);
+});
+
+// API route to serve Search data to React client
+app.get('/api/search', function(req, res) {
+  const userQuery = req.query.q;
+
+  // Check for poison null byte in query
+  if (userQuery.indexOf('\0') !== -1) {
+    // If a poison null byte is present in the query, return no results
+    res.sendFile(path.join(__dirname, 'data', 'search', 'xml', 'default-no-results.xml'));
+  } else {
+    // Avoid path traversal by removing unescaped traversal characters
+    const safeQuery = path.normalize(userQuery).replace(/^(\.\.(\/|\\|$))+/, '');
+    const safePath = path.join(__dirname, 'data', 'search', 'xml', safeQuery + '.xml');
+
+    // Check if we have data for the query by
+    // attempting to open XML file in read mode
+    fs.open(safePath, 'r')
+      .then((xmlFileHandle) => {
+        res.sendFile(safePath);
+
+        // FileHandle must be closed manually
+        xmlFileHandle.close();
+      })
+      .catch((err) => {
+        if (err.code === 'ENOENT') {
+          // No data file exists for the query, return no results
+          res.sendFile(path.join(__dirname, 'data', 'search', 'xml', 'default-no-results.xml'));
+        } else {
+          console.log(err);
+        }
+      });
+  }
 });
 
 app.post('/api/login', function(req, res) {


### PR DESCRIPTION
This PR adds a search engine result page (SERP) that takes user queries, contacts a new back-end Search API, and displays results in a rudimentary list.

**Back-end**
- Express server is updated with an API route (`/api/search`) that looks for query parameters in the form `?q=example` and sends back XML
- XML data files (in Google Search Appliance format) are included for a default case (no results) plus the search terms "jobs" and "msp" from the production search appliance

**Front-end**
- SearchBar component is extended with an `initialInput` prop to set an initial value for its input field and an `onButtonClick` prop for use as a callback to parent components
- SearchBar button functionality is now enabled if an `onButtonClick` prop is present
- SearchBar styling is updated to show an enabled state with a darker color on the icon
- LoadSpinner component is added to be displayed while awaiting results from the API call
- `axios` and `xml2js` are added as front-end dependencies to support the new call to the Search API
- The Search page is updated with handling for searching using these cases:
  - Users can go directly to a search result page with a link (`/search?q=msp`)
  - On the Search page, users can enter a new query, submit it, and their browser history is updated to the new SERP
  - SERP can display a list of results (just a simple series of paragraphs of page titles for now) or a message saying there were no results