### PR TITLE
Search engine result page buildout

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.1",
       "dependencies": {
         "@bcgov/bc-sans": "1.0.1",
-        "axios": "^0.21.1",
-        "core-js": "3.9.1",
+        "axios": "0.21.1",
+        "core-js": "3.11.0",
         "dompurify": "2.2.7",
         "node-sass": "5.0.0",
         "react": "17.0.2",
@@ -22,14 +22,14 @@
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
         "react-tooltip": "4.2.17",
-        "styled-components": "5.2.1",
-        "xml2js": "^0.4.23"
+        "styled-components": "5.2.3",
+        "xml2js": "0.4.23"
       },
       "devDependencies": {
-        "@babel/core": "7.13.10",
-        "@testing-library/jest-dom": "5.11.10",
-        "@testing-library/react": "11.2.5",
-        "@testing-library/user-event": "13.0.16",
+        "@babel/core": "7.13.16",
+        "@testing-library/jest-dom": "5.12.0",
+        "@testing-library/react": "11.2.6",
+        "@testing-library/user-event": "13.1.5",
         "husky": "4.3.8",
         "lint-staged": "10.5.4",
         "prettier": "2.2.1",
@@ -49,29 +49,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog=="
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
     },
     "node_modules/@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.13.14",
+        "@babel/helpers": "^7.13.16",
+        "@babel/parser": "^7.13.16",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
@@ -84,11 +83,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
       "dependencies": {
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.16",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -111,11 +110,11 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
       "dependencies": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.15",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -205,35 +204,34 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
       "dependencies": {
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "lodash": "^4.17.19"
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
@@ -260,22 +258,22 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
@@ -316,13 +314,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+      "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
       "dependencies": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/traverse": "^7.13.17",
+        "@babel/types": "^7.13.17"
       }
     },
     "node_modules/@babel/highlight": {
@@ -336,9 +334,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1374,28 +1372,26 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.16",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.16",
+        "@babel/types": "^7.13.17",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -2861,9 +2857,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.11.10",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz",
-      "integrity": "sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.12.0.tgz",
+      "integrity": "sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2",
@@ -2949,9 +2945,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz",
-      "integrity": "sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
+      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2966,9 +2962,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.0.16",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.0.16.tgz",
-      "integrity": "sha512-plXL8lGR2H0xm0fHE0Dfz37ke2UtBI1wAmaWIo6BP7+pGt+BxdBQrITHAMGcac0a3PtBi5CXNPth8S53ISO1Ew==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.5.tgz",
+      "integrity": "sha512-dD1FRHuWhfdcnb6H9/oaIIZHx9LQKGxbTtYV3i5Zru8I3GWWJoG2WtlAlXZ/56djO+6TvfsWPj5cXQvoTFQATQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -5900,9 +5896,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -20583,16 +20579,16 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
-      "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.3.tgz",
+      "integrity": "sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
         "@emotion/is-prop-valid": "^0.8.8",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1",
+        "babel-plugin-styled-components": ">= 1.12.0",
         "css-to-react-native": "^3.0.0",
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
@@ -23779,39 +23775,38 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog=="
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
     },
     "@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.13.14",
+        "@babel/helpers": "^7.13.16",
+        "@babel/parser": "^7.13.16",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
       }
     },
     "@babel/generator": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
       "requires": {
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.16",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -23834,11 +23829,11 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.15",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -23916,35 +23911,34 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
       "requires": {
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "lodash": "^4.17.19"
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -23971,22 +23965,22 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -24027,13 +24021,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+      "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
       "requires": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/traverse": "^7.13.17",
+        "@babel/types": "^7.13.17"
       }
     },
     "@babel/highlight": {
@@ -24047,9 +24041,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ=="
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.13.8",
@@ -24841,28 +24835,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.16",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.16",
+        "@babel/types": "^7.13.17",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -25924,9 +25916,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.11.10",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz",
-      "integrity": "sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.12.0.tgz",
+      "integrity": "sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -25991,9 +25983,9 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz",
-      "integrity": "sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
+      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
@@ -26001,9 +25993,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.0.16",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.0.16.tgz",
-      "integrity": "sha512-plXL8lGR2H0xm0fHE0Dfz37ke2UtBI1wAmaWIo6BP7+pGt+BxdBQrITHAMGcac0a3PtBi5CXNPth8S53ISO1Ew==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.5.tgz",
+      "integrity": "sha512-dD1FRHuWhfdcnb6H9/oaIIZHx9LQKGxbTtYV3i5Zru8I3GWWJoG2WtlAlXZ/56djO+6TvfsWPj5cXQvoTFQATQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
@@ -28387,9 +28379,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
     },
     "core-js-compat": {
       "version": "3.9.1",
@@ -39689,16 +39681,16 @@
       }
     },
     "styled-components": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
-      "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.3.tgz",
+      "integrity": "sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
         "@emotion/is-prop-valid": "^0.8.8",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1",
+        "babel-plugin-styled-components": ">= 1.12.0",
         "css-to-react-native": "^3.0.0",
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",
-    "axios": "^0.21.1",
-    "core-js": "3.9.1",
+    "axios": "0.21.1",
+    "core-js": "3.11.0",
     "dompurify": "2.2.7",
     "node-sass": "5.0.0",
     "react": "17.0.2",
@@ -17,14 +17,14 @@
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "react-tooltip": "4.2.17",
-    "styled-components": "5.2.1",
-    "xml2js": "^0.4.23"
+    "styled-components": "5.2.3",
+    "xml2js": "0.4.23"
   },
   "devDependencies": {
-    "@babel/core": "7.13.10",
-    "@testing-library/jest-dom": "5.11.10",
-    "@testing-library/react": "11.2.5",
-    "@testing-library/user-event": "13.0.16",
+    "@babel/core": "7.13.16",
+    "@testing-library/jest-dom": "5.12.0",
+    "@testing-library/react": "11.2.6",
+    "@testing-library/user-event": "13.1.5",
     "husky": "4.3.8",
     "lint-staged": "10.5.4",
     "prettier": "2.2.1",

--- a/react-app/src/components/SearchBar.js
+++ b/react-app/src/components/SearchBar.js
@@ -60,6 +60,15 @@ const SearchButton = styled.button`
   [disabled] {
     cursor: not-allowed;
   }
+
+  &:focus {
+    background-color: #f2f2f2;
+    outline: 4px solid #3b99fc;
+  }
+
+  &:hover {
+    background-color: #f2f2f2;
+  }
 `;
 
 function SearchBar({

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -21,6 +21,41 @@ const StyledSearchResults = styled.main`
     margin-top: 24px;
   }
 
+  div.result {
+    display: flex;
+    flex-direction: row;
+    align-items: top;
+    margin: 50px 0;
+
+    div.text {
+      display: inline-block;
+      padding: 0 32px 0 0;
+      width: 80%;
+
+      a.title {
+        color: #003366;
+        cursor: pointer;
+        display: block;
+        font-size: 24px;
+        font-weight: 700;
+        text-decoration: none;
+
+        &:hover {
+          color: #1a5a96;
+          text-decoration: underline;
+        }
+      }
+    }
+
+    div.image {
+      background-color: #f2f2f2;
+      content: "";
+      display: inline-block;
+      height: 150px;
+      width: 20%;
+    }
+  }
+
   ul {
     li {
       margin: 10px 0;
@@ -149,7 +184,36 @@ function Search() {
         Object.keys(state?.results).length > 0 &&
         state?.results?.GSP?.RES &&
         state?.results?.GSP?.RES[0]?.R?.map((result, index) => {
-          return <p key={`result-${index}`}>{result.T}</p>;
+          return (
+            <div className="result" key={`result-${index}`}>
+              <div className="text">
+                {/* Title (without trailing "- Province of BC") */}
+                <a className="title" href={result?.UE}>
+                  {result?.MT?.length > 0 &&
+                    result?.MT?.map((metaTag) => {
+                      // Note misspelling of "navigation" to match API data
+                      if (metaTag?.$?.N === "navigaton_title") {
+                        return metaTag?.$?.V;
+                      }
+                    })}
+                </a>
+
+                {/* Description */}
+                <p className="description">
+                  {result?.MT?.length > 0 &&
+                    result?.MT?.map((metaTag) => {
+                      // Note misspelling of "navigation" to match API data
+                      if (metaTag?.$?.N === "description") {
+                        return metaTag?.$?.V;
+                      }
+                    })}
+                </p>
+              </div>
+
+              {/* Preview image */}
+              <div className="image"></div>
+            </div>
+          );
         })}
 
       {/* Message indicating no results if applicable */}

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -24,10 +24,10 @@ function useQuery() {
 
 function Search() {
   const [state, setState] = useState({
-    query: useQuery().get("q"), // Query parameter is in the form `?q=example`
+    query: useQuery().get("q") || "", // Query parameter is in the form `?q=example`
     isLoading: useQuery().get("q") ? true : false,
     results: {},
-    newQuery: useQuery().get("q"),
+    newQuery: useQuery().get("q") || "",
   });
 
   let history = useHistory();

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -13,6 +13,12 @@ const StyledSearchResults = styled.main`
     font-size: 36px;
     font-weight: 400;
   }
+
+  ul {
+    li {
+      margin: 10px 0;
+    }
+  }
 `;
 
 // Use the URLSearchParams API to parse the the query string
@@ -98,6 +104,7 @@ function Search() {
 
       {state?.query?.length > 0 ? (
         <h1>
+          {/* Page title */}
           Search results for <strong>{`"${state.query}"`}</strong>
         </h1>
       ) : (
@@ -114,19 +121,38 @@ function Search() {
       {/* Show a load spinner until the API request is completed */}
       {state?.isLoading && <LoadSpinner />}
 
-      {/* Show a list of results or a message explaining there are no results */}
-      {state?.results &&
-      Object.keys(state?.results).length > 0 &&
-      state?.results?.GSP?.RES ? (
-        state?.results?.GSP?.RES[0]?.R?.map((result) => {
-          return <p>{result.T}</p>;
-        })
-      ) : (
-        <p>
-          Your search - <strong>{state.query}</strong> - did not match any
-          documents.
-        </p>
-      )}
+      {/* Show a list of results if applicable */}
+      {!state?.isLoading &&
+        state?.query?.length > 0 &&
+        state?.results &&
+        Object.keys(state?.results).length > 0 &&
+        state?.results?.GSP?.RES &&
+        state?.results?.GSP?.RES[0]?.R?.map((result, index) => {
+          return <p key={`result-${index}`}>{result.T}</p>;
+        })}
+
+      {/* Show a message indicating no results if applicable */}
+      {!state?.isLoading &&
+        state?.query?.length > 0 &&
+        state?.results &&
+        Object.keys(state?.results).length > 0 &&
+        !state?.results?.GSP?.hasOwnProperty("RES") && (
+          <>
+            <p>
+              Your search - <strong>{state.query}</strong> - did not match any
+              documents.
+            </p>
+            <p>Suggestions:</p>
+            <ul>
+              <li>Make sure all words are spelled correctly.</li>
+              <li>
+                Try a different keyword like <strong>"MSP"</strong> or{" "}
+                <strong>"jobs"</strong>.
+              </li>
+              <li>Try more generic keywords.</li>
+            </ul>
+          </>
+        )}
     </StyledSearchResults>
   );
 }

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -43,13 +43,16 @@ function Search() {
   // Callback provided to SearchBar to conduct a new search
   function submitNewQuery(event) {
     event.preventDefault();
-    history.push(`/search?q=${state.newQuery}`);
-    setState({
-      query: state?.newQuery,
-      isLoading: state?.newQuery ? true : false,
-      results: {},
-      newQuery: state?.newQuery,
-    });
+    // Don't do a new search with the same query
+    if (state?.query !== state?.newQuery) {
+      history.push(`/search?q=${state.newQuery}`);
+      setState({
+        query: state?.newQuery,
+        isLoading: state?.newQuery ? true : false,
+        results: {},
+        newQuery: state?.newQuery,
+      });
+    }
   }
 
   useEffect(() => {

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -9,6 +9,8 @@ import LoadSpinner from "../../components/LoadSpinner";
 import SearchBar from "../../components/SearchBar";
 
 const StyledSearchResults = styled.main`
+  max-width: 767px;
+
   h1 {
     font-size: 36px;
     font-weight: 400;

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -14,6 +14,11 @@ const StyledSearchResults = styled.main`
     font-weight: 400;
   }
 
+  p.results-found {
+    font-size: 16px;
+    margin-top: 24px;
+  }
+
   ul {
     li {
       margin: 10px 0;
@@ -102,9 +107,9 @@ function Search() {
         />
       </Helmet>
 
+      {/* Page title */}
       {state?.query?.length > 0 ? (
         <h1>
-          {/* Page title */}
           Search results for <strong>{`"${state.query}"`}</strong>
         </h1>
       ) : (
@@ -118,23 +123,36 @@ function Search() {
         parentCallback={updateNewQuery}
       />
 
-      {/* Show a load spinner until the API request is completed */}
+      {/* LoadSpinner until the API request is completed */}
       {state?.isLoading && <LoadSpinner />}
 
-      {/* Show a list of results if applicable */}
+      {/* Count of results found */}
       {!state?.isLoading &&
         state?.query?.length > 0 &&
-        state?.results &&
+        Object.keys(state?.results).length > 0 &&
+        state?.results?.GSP?.RES &&
+        state?.results?.GSP?.RES[0]?.M && (
+          <p className="results-found">
+            Found{" "}
+            <strong>
+              {new Intl.NumberFormat().format(state?.results?.GSP?.RES[0]?.M)}
+            </strong>{" "}
+            results
+          </p>
+        )}
+
+      {/* List of results if applicable */}
+      {!state?.isLoading &&
+        state?.query?.length > 0 &&
         Object.keys(state?.results).length > 0 &&
         state?.results?.GSP?.RES &&
         state?.results?.GSP?.RES[0]?.R?.map((result, index) => {
           return <p key={`result-${index}`}>{result.T}</p>;
         })}
 
-      {/* Show a message indicating no results if applicable */}
+      {/* Message indicating no results if applicable */}
       {!state?.isLoading &&
         state?.query?.length > 0 &&
-        state?.results &&
         Object.keys(state?.results).length > 0 &&
         !state?.results?.GSP?.hasOwnProperty("RES") && (
           <>

--- a/react-app/src/pages/Services/index.js
+++ b/react-app/src/pages/Services/index.js
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 import { Service } from "../../components/Service";
 import { ServiceHighlight } from "../../components/ServiceHighlight";
+import LoadSpinner from "../../components/LoadSpinner";
 
 const ServicesContentStyled = styled.div`
   div.div--search {
@@ -149,6 +150,7 @@ const ServicesContentStyled = styled.div`
 function ServicesContent() {
   const [services, setServices] = useState({});
   const [inputValue, setInputValue] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
 
   async function fetchData() {
     const res = await fetch("/api/services");
@@ -156,6 +158,8 @@ function ServicesContent() {
       .json()
       .then((res) => setServices(res.services))
       .catch((err) => console.log(err));
+
+    setIsLoading(false);
   }
 
   useEffect(() => {
@@ -217,6 +221,7 @@ function ServicesContent() {
       </div>
 
       {/* Services list */}
+      {isLoading && <LoadSpinner />}
       {services &&
         services.length > 0 &&
         services


### PR DESCRIPTION
This PR adds functionality to the Search page for displaying results:
- The `query` and `newQuery` parameters built with the `URLSearchParams` API are coerced to empty strings from `null` when there is no query present for easier handling
- A new GET request to the Search API will only occur if the `newQuery` state is different from the existing `query` state to avoid erroneous re-loads
- Logic around SERP results is fixed and built out so that it now displays results in a div with the result title (as a link), result description, and a blank area to the right for preview images TBD
- A count of results is added to the SERP
- `max-width` is added to the SERP `<main>` tag to match the wireframe

Additionally:
- Front-end dependencies are bumped to latest where possible
- LoadSpinner component is added to the Services page for a visual indication while fetching data
- SearchBar button has `:focus` and `:hover` styling added