### PR TITLE
Search refactor, console warning cleanup

### DIFF
--- a/data/search/xml/jobs/2.xml
+++ b/data/search/xml/jobs/2.xml
@@ -8,7 +8,7 @@
    <PARAM name="getfields" original_value="*" value="*"/>
    <PARAM name="q" original_value="jobs" value="jobs"/>
    <RES EN="20" SN="11">
-      <M>2480</M>
+      <M>30</M>
       <FI/>
       <NB>
          <PU>/search?site=default_collection&amp;client=default_frontend&amp;q=jobs&amp;num=10&amp;start=0</PU>

--- a/data/search/xml/jobs/3.xml
+++ b/data/search/xml/jobs/3.xml
@@ -8,7 +8,7 @@
    <PARAM name="getfields" original_value="*" value="*"/>
    <PARAM name="q" original_value="jobs" value="jobs"/>
    <RES EN="30" SN="21">
-      <M>11300</M>
+      <M>30</M>
       <FI/>
       <NB>
          <PU>/search?site=default_collection&amp;client=default_frontend&amp;q=jobs&amp;num=10&amp;start=10</PU>

--- a/data/search/xml/msp/2.xml
+++ b/data/search/xml/msp/2.xml
@@ -8,7 +8,7 @@
    <PARAM name="getfields" original_value="*" value="*"/>
    <PARAM name="q" original_value="msp" value="msp"/>
    <RES EN="20" SN="11">
-      <M>597</M>
+      <M>20</M>
       <FI/>
       <NB>
          <PU>/search?site=default_collection&amp;client=default_frontend&amp;q=msp&amp;num=10&amp;start=0</PU>

--- a/react-app/src/components/Header/Nav/SlideOutMenu.js
+++ b/react-app/src/components/Header/Nav/SlideOutMenu.js
@@ -6,9 +6,9 @@ import styled from "styled-components";
 import constructionMessage from "../../../pages/Under-Construction/message";
 import Alert from "../Alert";
 
-import { ReactComponent as PersonIcon } from "../../assets/ionic-md-person.svg";
+// import { ReactComponent as PersonIcon } from "../../assets/ionic-md-person.svg";
 import { ReactComponent as SearchIcon } from "../../assets/search-solid.svg";
-import { ReactComponent as LanguageIcon } from "../../assets/language-solid.svg";
+// import { ReactComponent as LanguageIcon } from "../../assets/language-solid.svg";
 
 const Cover = styled.div`
   background: rgba(0, 0, 0, 0.7);

--- a/react-app/src/components/Header/Nav/index.js
+++ b/react-app/src/components/Header/Nav/index.js
@@ -5,8 +5,8 @@ import MediaQuery from "react-responsive";
 import styled from "styled-components";
 
 import SearchButton from "./SearchButton";
-import UserPanel from "./UserPanel";
-import LanguagePicker from "./LanguagePicker";
+// import UserPanel from "./UserPanel";
+// import LanguagePicker from "./LanguagePicker";
 import { ReactComponent as HamburgerIcon } from "../../assets/bars-solid.svg";
 
 const NavStyled = styled.nav`

--- a/react-app/src/components/TableGroup.js
+++ b/react-app/src/components/TableGroup.js
@@ -215,6 +215,9 @@ function TableGroup({ context = {}, data, id }) {
           }
         }
       }
+      // .sort() expects a return value and will cause a React warning if
+      // this isn't explicitly set here
+      return 0;
     });
   }
 

--- a/react-app/src/pages/Home/Highlights.js
+++ b/react-app/src/pages/Home/Highlights.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 import Icon from "../../components/Icon";

--- a/react-app/src/pages/Home/Personalization.js
+++ b/react-app/src/pages/Home/Personalization.js
@@ -300,7 +300,9 @@ function Personalization({ personalization, parentCallback, searchTerm }) {
                     );
                   }
 
-                  // return null;
+                  // .map() expects an explicit return value, and React will
+                  // throw a warning if this is not present
+                  return null;
                 })}
 
               {/* Right arrow to display more columns when there are 5 or more */}

--- a/react-app/src/pages/Logout/index.js
+++ b/react-app/src/pages/Logout/index.js
@@ -11,14 +11,9 @@ const StyledMain = styled.main`
   padding: 0 10px;
 `;
 
-function Login(props) {
+function Logout(props) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoggedOut, setIsLoggedOut] = useState(false);
-
-  const referer =
-    props.location && props.location.state && props.location.state.referer
-      ? props.location.state.referer
-      : "/";
 
   function postLogout(event) {
     event.preventDefault();
@@ -37,7 +32,7 @@ function Login(props) {
 
       <h1>Logout</h1>
       <form
-        id="form--login"
+        id="form--logout"
         method="post"
         onSubmit={(e) => {
           postLogout(e);
@@ -56,11 +51,11 @@ function Login(props) {
   );
 }
 
-Login.propTypes = {
+Logout.propTypes = {
   title: propTypes.string,
   breadcrumbs: propTypes.array,
 };
 
-Login.defaultProps = {};
+Logout.defaultProps = {};
 
-export default Login;
+export default Logout;

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -289,6 +289,9 @@ function Search() {
               if (metaTag?.$?.N === "navigaton_title") {
                 return metaTag?.$?.V;
               }
+              // .map() expects an explicit return value and React will throw
+              // a warning if this is not present
+              return null;
             })}
         </a>
       );
@@ -458,6 +461,9 @@ function Search() {
                       if (metaTag?.$?.N === "description") {
                         return metaTag?.$?.V;
                       }
+                      // .map() expects an explicit return value and React will
+                      // throw a warning if this is not present
+                      return null;
                     })}
                 </p>
               </div>

--- a/react-app/src/useDocumentScrollThrottled.js
+++ b/react-app/src/useDocumentScrollThrottled.js
@@ -26,7 +26,7 @@ function useDocumentScrollThrottled(callback) {
 
     return () =>
       window.removeEventListener("scroll", handleDocumentScrollThrottled);
-  }, []);
+  }, [handleDocumentScrollThrottled]);
 }
 
 export default useDocumentScrollThrottled;


### PR DESCRIPTION
This PR refactors the Search page state to limit re-renders and deals with many long-standing console warnings.

Search front-end
- Rather than using a single `state` object, state is broken apart into individual variables to prevent issues with React re-rendering too frequently (b0256f3)
- An outstanding `useEffect()` ESLint warning is still here with a TODO, and should be looked at in the future when I'm better at this hook

Misc
- Unused import statements (which are used by commented-out code) are commented out to quiet console warnings (c602ae4)
- `.sort()` and `.map()` instances have default `null` return values added in cases where there is not already a default return value (a22bd64, 7f2af51, c219d27)
- XML data used by the Search API is updated to manually change the total result counts to keep them consistent across files (06e8991)
- `useDocumentScrollThrottled` has its `useEffect()` dependency array updated to make ESLint happy (46d4cb2)