### PR TITLE
Search page result title and description handling

### DIFF
--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -321,44 +321,28 @@ function Search() {
   }
 
   function getResultTitle(result) {
-    // Page (non-document) results should have a metatag for "navigaton_title"
-    // and no explicit MIME type set.
-    if (!result?.$?.MIME) {
+    // All (1) or Services (4) tabs
+    if (tab === 1 || tab === 4) {
       return (
         <a className="title" href={result?.UE}>
-          {result?.MT?.length > 0 &&
-            result?.MT?.map((metaTag) => {
-              // Note misspelling of "navigation" to match API data
-              if (metaTag?.$?.N === "navigaton_title") {
-                return metaTag?.$?.V;
-              }
-              // .map() expects an explicit return value and React will throw
-              // a warning if this is not present
-              return null;
-            })}
+          {result?.T?.toString().split(" - Province of British Columbia", 1)[0]}
+        </a>
+      );
+      // News (2) tab
+    } else if (tab === 2) {
+      return (
+        <a className="title" href={result?.UE}>
+          {result?.T?.toString().split(" | BC Gov News", 1)[0]}
+        </a>
+      );
+      // Documents tab (3) and default
+    } else {
+      return (
+        <a className="title" href={result?.UE}>
+          {result?.T}
         </a>
       );
     }
-
-    // Document results should have a title (without suffix) which we prefer,
-    // or a filename that can be used if the title is absent.
-    let title = "";
-    let fileName = "";
-
-    result?.MT?.forEach((metaTag) => {
-      if (metaTag?.$?.N === "title") {
-        title = metaTag?.$?.V;
-      }
-      if (metaTag?.$?.N === "DCTERMS.filename") {
-        fileName = metaTag?.$?.V;
-      }
-    });
-
-    return (
-      <a className="title" href={result?.UE}>
-        {title ? title : fileName}
-      </a>
-    );
   }
 
   // Run on first render and each time `query` or `tab` change

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -335,12 +335,40 @@ function Search() {
           {result?.T?.toString().split(" | BC Gov News", 1)[0]}
         </a>
       );
-      // Documents tab (3) and default
+      // Documents (3) tab and default
     } else {
       return (
         <a className="title" href={result?.UE}>
           {result?.T}
         </a>
+      );
+    }
+  }
+
+  function getResultDescription(result) {
+    // Documents (3) tab
+    if (tab === 3) {
+      return (
+        <p
+          className="description"
+          dangerouslySetInnerHTML={{ __html: result?.S?.toString() }}
+        />
+      );
+
+      // All (1), Services (4), News (2) tabs and default
+    } else {
+      return (
+        <p className="description">
+          {result?.MT?.length > 0 &&
+            result?.MT?.map((metaTag) => {
+              if (metaTag?.$?.N === "description") {
+                return metaTag?.$?.V;
+              }
+              // .map() expects an explicit return value and React will
+              // throw a warning if this is not present
+              return null;
+            })}
+        </p>
       );
     }
   }
@@ -436,17 +464,7 @@ function Search() {
                 {getResultTitle(result)}
 
                 {/* Description */}
-                <p className="description">
-                  {result?.MT?.length > 0 &&
-                    result?.MT?.map((metaTag) => {
-                      if (metaTag?.$?.N === "description") {
-                        return metaTag?.$?.V;
-                      }
-                      // .map() expects an explicit return value and React will
-                      // throw a warning if this is not present
-                      return null;
-                    })}
-                </p>
+                {getResultDescription(result)}
               </div>
 
               {/* Preview image */}


### PR DESCRIPTION
This PR adds functionality to handle search result titles and descriptions for all tab (filter) cases.

- `getResultTitle()` is simplified to remove loops by using string splits on the production titles to remove suffixes (39818d9)
- Result descriptions are refactored into `getResultDescription()` which now handles Documents using the GSA result `<S>` node