### PR TITLE
Fix redirect logic in PrivateRoute component and Login page

### DIFF
--- a/react-app/src/PrivateRoute.js
+++ b/react-app/src/PrivateRoute.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
-import { Route, Redirect } from "react-router-dom";
+import { Route, Redirect, useLocation } from "react-router-dom";
 
 import Page from "./components/Page";
 
@@ -13,6 +13,10 @@ function PrivateRoute({
   parentTitle,
   ...rest
 }) {
+  const location = useLocation();
+  const referer = location?.pathname || "/";
+  const params = location?.search || "";
+
   return localStorage.getItem("user") ? (
     <Route {...rest}>
       {/* By defining the Helmet defaults here, we can keep the BC branding out
@@ -32,7 +36,15 @@ function PrivateRoute({
       />
     </Route>
   ) : (
-    <Redirect to={{ pathname: "/login", state: { referer: "/" } }} />
+    <Redirect
+      to={{
+        pathname: "/login",
+        state: {
+          referer: referer,
+          params: params,
+        },
+      }}
+    />
   );
 }
 

--- a/react-app/src/pages/Login/index.js
+++ b/react-app/src/pages/Login/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import propTypes from "prop-types";
 import { Helmet } from "react-helmet";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import { userService } from "../../_services/user.service";
@@ -13,16 +13,19 @@ const StyledMain = styled.main`
   padding: 0 10px;
 `;
 
-function Login(props) {
+function Login() {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isLoggedIn, setLoggedIn] = useState(false);
+  const [isLoggedIn, setLoggedIn] = useState(
+    Boolean(localStorage.getItem("user"))
+  );
   const [isError, setIsError] = useState(false);
   const [userName, setUserName] = useState("");
   const [password, setPassword] = useState("");
-  const referer =
-    props.location && props.location.state && props.location.state.referer
-      ? props.location.state.referer
-      : "/";
+  const history = useHistory();
+
+  // history object state items are set in PrivateRoute
+  const referer = history?.location?.state?.referer || document.referrer || "/";
+  const params = history?.location?.state?.params || "";
 
   function postLogin(event) {
     event.preventDefault();
@@ -40,7 +43,7 @@ function Login(props) {
   }
 
   if (isLoggedIn) {
-    return <Redirect to={referer} />;
+    return <Redirect to={`${referer}${params}`} />;
   }
 
   return (


### PR DESCRIPTION
This PR adds redirect logic to the PrivateRoute wrapper component and Login page so that a user's initial landing page gets recorded by the PrivateRoute (68f55c6) and passed to a `<Redirect>` to the Login page. Now, users who are logging in will not be directed to `/` unless that was the page they initially requested or no referrer is detected (396e2e1).

For `/search` route requests with URL parameters (`?q=example&tab=1`), the parameters are passed by PrivateRoute to allow the Search page to render the search results as expected.