### PR TITLE
Tests for Search/Result component

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -33,7 +33,8 @@
         "husky": "4.3.8",
         "lint-staged": "11.0.0",
         "prettier": "2.2.1",
-        "react-is": "17.0.2"
+        "react-is": "17.0.2",
+        "react-test-renderer": "^17.0.2"
       },
       "engines": {
         "node": "14.16.0",
@@ -17976,12 +17977,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
       }
     },
     "node_modules/react-tooltip": {
@@ -37566,11 +37595,33 @@
         }
       }
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
     "react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
       "requires": {}
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      }
     },
     "react-tooltip": {
       "version": "4.2.19",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -28,7 +28,8 @@
     "husky": "4.3.8",
     "lint-staged": "11.0.0",
     "prettier": "2.2.1",
-    "react-is": "17.0.2"
+    "react-is": "17.0.2",
+    "react-test-renderer": "^17.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react-app/src/pages/Search/Result/__mocks__/mockResultData.js
+++ b/react-app/src/pages/Search/Result/__mocks__/mockResultData.js
@@ -1,0 +1,1097 @@
+// All tab
+const mockResultTab1 = {
+  $: {
+    N: "2",
+  },
+  U: [
+    "https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp",
+  ],
+  UE: [
+    "https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp",
+  ],
+  T: ["Medical Services Plan (MSP) - Province of British Columbia"],
+  RK: ["65.25052333540559"],
+  ENT_SOURCE: [""],
+  FS: [
+    {
+      $: {
+        NAME: "date",
+        VALUE: "2018-12-18",
+      },
+    },
+  ],
+  MT: [
+    {
+      $: {
+        N: "query_id",
+        V: "20971215157526",
+      },
+    },
+    {
+      $: {
+        N: "prev_query_id",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "datasource/modificationDate",
+        V: "1545166174000",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.creator",
+        V: "BC Public Service Agency",
+      },
+    },
+    {
+      $: {
+        N: "security_classification",
+        V: "Low",
+      },
+    },
+    {
+      $: {
+        N: "datasource/category",
+        V: "Web",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.subject",
+        V: "Benefits",
+      },
+    },
+    {
+      $: {
+        N: "level1_id",
+        V: "C6D1F618844441778AD409A9C99C1CD3",
+      },
+    },
+    {
+      $: {
+        N: "keywords",
+        V: "eligibility",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.current_page",
+        V: "Medical Services Plan (MSP)",
+      },
+    },
+    {
+      $: {
+        N: "mes:date",
+        V: "1545166174000",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.publisher",
+        V: "Province of British Columbia",
+      },
+    },
+    {
+      $: {
+        N: "title",
+        V: "Medical Services Plan (MSP) - Province of British Columbia",
+      },
+    },
+    {
+      $: {
+        N: "content",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "Content-Type",
+        V: "text/html; charset=UTF-8",
+      },
+    },
+    {
+      $: {
+        N: "level2_id",
+        V: "015013A6A838410593D05F257E80CDCF",
+      },
+    },
+    {
+      $: {
+        N: "datasource/fqcategory",
+        V: "Web:mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.created",
+        V: "2016-02-25",
+      },
+    },
+    {
+      $: {
+        N: "datasource/mes:key",
+        V:
+          "https://www2.gov.bc.ca/gov/content/careers-myhr/all-employees/pay-benefits/benefits/msp",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.modified",
+        V: "2018-12-18",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.creator",
+        V: "BC Public Service Agency",
+      },
+    },
+    {
+      $: {
+        N: "bcpsa_subjects",
+        V: "Employee benefits",
+      },
+    },
+    {
+      $: {
+        N: "bcpsa_subjects",
+        V: "Health",
+      },
+    },
+    {
+      $: {
+        N: "bcpsa_enhancedSearch",
+        V: "myhr",
+      },
+    },
+    {
+      $: {
+        N: "current_page",
+        V: "Medical Services Plan (MSP)",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level3",
+        V: "Pay & Benefits",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level4",
+        V: "Employee Benefits",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level5",
+        V: "Medical Services Plan (MSP)",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level1",
+        V: "Careers & MyHR",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level2",
+        V: "All Employees",
+      },
+    },
+    {
+      $: {
+        N: "datasource/categoryinstance",
+        V: "mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "description",
+        V: "Information on both included and excluded benefits eligibility.",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.language",
+        V: "eng",
+      },
+    },
+    {
+      $: {
+        N: "level3_id",
+        V: "1B7D1F2DB611456C8A475583D93CD94C",
+      },
+    },
+    {
+      $: {
+        N: "collections",
+        V: "mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "mes:size",
+        V: "99729.0",
+      },
+    },
+    {
+      $: {
+        N: "level5",
+        V: "Medical Services Plan (MSP)",
+      },
+    },
+    {
+      $: {
+        N: "level4",
+        V: "Employee Benefits",
+      },
+    },
+    {
+      $: {
+        N: "current_page_id",
+        V: "EFAF2399E3F04F52A4D204C527BF855E",
+      },
+    },
+    {
+      $: {
+        N: "level1",
+        V: "Careers & MyHR",
+      },
+    },
+    {
+      $: {
+        N: "level3",
+        V: "Pay & Benefits",
+      },
+    },
+    {
+      $: {
+        N: "level2",
+        V: "All Employees",
+      },
+    },
+    {
+      $: {
+        N: "extension",
+        V: "html",
+      },
+    },
+    {
+      $: {
+        N: "security_label",
+        V: "Public ",
+      },
+    },
+    {
+      $: {
+        N: "categoryclass",
+        V: "default",
+      },
+    },
+    {
+      $: {
+        N: "CMF_ContentType",
+        V: "General Content",
+      },
+    },
+    {
+      $: {
+        N: "level4_id",
+        V: "CA745CED83314A7D9B54FA4E202F362C",
+      },
+    },
+    {
+      $: {
+        N: "navigaton_title",
+        V: "Medical Services Plan (MSP)",
+      },
+    },
+    {
+      $: {
+        N: "MBCTERMS.subjectCategory",
+        V: "Labour",
+      },
+    },
+    {
+      $: {
+        N: "level5_id",
+        V: "EFAF2399E3F04F52A4D204C527BF855E",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.audience",
+        V: "Provincial Government",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS:interactiveResource",
+        V: "Topic",
+      },
+    },
+  ],
+  S: [
+    "Your Personal Information\n<b>Medical Services Plan (MSP</b>)\nThis content has...your bookmarks.\nFor <b>Medical Services Plan (MSP</b>) information for BC",
+  ],
+  LANG: [""],
+  HAS: [
+    {
+      L: [""],
+      C: [
+        {
+          $: {
+            CID: "",
+            ENC: "",
+            SZ: "97.39k",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// News tab
+const mockResultTab2 = {
+  $: {
+    N: "1",
+  },
+  U: ["https://news.gov.bc.ca/releases/2019HLTH0114-001555"],
+  UE: ["https://news.gov.bc.ca/releases/2019HLTH0114-001555"],
+  T: [
+    "International students continue to contribute to B.C. health care as MSP premiums eliminated | BC Gov News",
+  ],
+  RK: ["80.11602865172458"],
+  ENT_SOURCE: [""],
+  FS: [
+    {
+      $: {
+        NAME: "date",
+        VALUE: "2019-08-01",
+      },
+    },
+  ],
+  MT: [
+    {
+      $: {
+        N: "query_id",
+        V: "52908052052410",
+      },
+    },
+    {
+      $: {
+        N: "prev_query_id",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "datasource/modificationDate",
+        V: "1619835166000",
+      },
+    },
+    {
+      $: {
+        N: "path",
+        V: "releases",
+      },
+    },
+    {
+      $: {
+        N: "datasource/category",
+        V: "Web",
+      },
+    },
+    {
+      $: {
+        N: "mes:date",
+        V: "1564642800000",
+      },
+    },
+    {
+      $: {
+        N: "title",
+        V:
+          "International students continue to contribute to B.C. health care as MSP premiums eliminated | BC Gov News",
+      },
+    },
+    {
+      $: {
+        N: "content",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "mes:existingmodificationdate",
+        V: "20210430064855",
+      },
+    },
+    {
+      $: {
+        N: "referer",
+        V: "https://news.gov.bc.ca/sitemap/html",
+      },
+    },
+    {
+      $: {
+        N: "datasource/fqcategory",
+        V: "Web:News gov BC",
+      },
+    },
+    {
+      $: {
+        N: "datasource/mes:key",
+        V: "https://news.gov.bc.ca/releases/2019HLTH0114-001555",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.creator",
+        V: "Health",
+      },
+    },
+    {
+      $: {
+        N: "datasource/categoryinstance",
+        V: "News gov BC",
+      },
+    },
+    {
+      $: {
+        N: "description",
+        V:
+          "As the Province eliminates Medical Service Plan (MSP) premiums for British Columbians, an updated payment method will ensure international students continue to contribute to, and benefit from, B.C.‘s health-care coverage.",
+      },
+    },
+    {
+      $: {
+        N: "mes:size",
+        V: "113796.0",
+      },
+    },
+    {
+      $: {
+        N: "extension",
+        V: "html",
+      },
+    },
+    {
+      $: {
+        N: "categoryclass",
+        V: "webpage",
+      },
+    },
+  ],
+  S: [
+    "Medical Service Plan (<b>MSP</b>) premiums for British...Under the old <b>MSP</b> system, international students...Jan. 1, 2020, <b>MSP</b> premiums will be...the elimination of <b>MSP</b> premiums, the health...legislation to end <b>MSP</b> premiums on Jan...Dix. “In eliminating <b>MSP</b> premiums for British...B.C.’s <b>MSP</b> premiums earlier this...per month in <b>MSP</b> premiums. On Sept...to contribute to <b>MSP</b> premiums was removed...1, 2020, when <b>MSP</b> premiums will be",
+  ],
+  LANG: [""],
+  HAS: [
+    {
+      L: [""],
+      C: [
+        {
+          $: {
+            CID: "",
+            ENC: "",
+            SZ: "111.13k",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// Documents tab
+const mockResultTab3 = {
+  $: {
+    MIME: "application/pdf",
+    N: "1",
+  },
+  U: [
+    "https://www2.gov.bc.ca/assets/gov/health/practitioner-pro/medical-services-plan/msp-service-locations-codes.pdf",
+  ],
+  UE: [
+    "https://www2.gov.bc.ca/assets/gov/health/practitioner-pro/medical-services-plan/msp-service-locations-codes.pdf",
+  ],
+  T: ["msp-service-locations-codes.pdf"],
+  RK: ["34.091512192074845"],
+  ENT_SOURCE: [""],
+  FS: [
+    {
+      $: {
+        NAME: "date",
+        VALUE: "2021-03-24",
+      },
+    },
+  ],
+  MT: [
+    {
+      $: {
+        N: "query_id",
+        V: "40030264553952",
+      },
+    },
+    {
+      $: {
+        N: "prev_query_id",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "datasource/modificationDate",
+        V: "1616614256000",
+      },
+    },
+    {
+      $: {
+        N: "document:created",
+        V: "1616536098000",
+      },
+    },
+    {
+      $: {
+        N: "datasource/category",
+        V: "Web",
+      },
+    },
+    {
+      $: {
+        N: "document:ContentType",
+        V: "application/pdf",
+      },
+    },
+    {
+      $: {
+        N: "mes:date",
+        V: "1616614256000",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.publisher",
+        V: "Province of British Columbia",
+      },
+    },
+    {
+      $: {
+        N: "title",
+        V: "msp-service-locations-codes.pdf",
+      },
+    },
+    {
+      $: {
+        N: "content",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "A23A6FFB4CD14778B5737BD4BCBB7656",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "85A6C31BB51F4DF4932EE92D0533E250",
+      },
+    },
+    {
+      $: {
+        N: "datasource/fqcategory",
+        V: "Web:mb_gov_assets_feed",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.filename",
+        V: "msp-service-locations-codes.pdf",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.created",
+        V: "2021-03-23",
+      },
+    },
+    {
+      $: {
+        N: "datasource/mes:key",
+        V:
+          "https://www2.gov.bc.ca/assets/gov/health/practitioner-pro/medical-services-plan/msp-service-locations-codes.pdf",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.modified",
+        V: "2021-03-24",
+      },
+    },
+    {
+      $: {
+        N: "document:modified",
+        V: "1616536098000",
+      },
+    },
+    {
+      $: {
+        N: "datasource/categoryinstance",
+        V: "mb_gov_assets_feed",
+      },
+    },
+    {
+      $: {
+        N: "document:date",
+        V: "1616536098000",
+      },
+    },
+    {
+      $: {
+        N: "collections",
+        V: "mb_gov_assets_feed",
+      },
+    },
+    {
+      $: {
+        N: "mes:size",
+        V: "123183.0",
+      },
+    },
+    {
+      $: {
+        N: "extension",
+        V: "pdf",
+      },
+    },
+    {
+      $: {
+        N: "categoryclass",
+        V: "default",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_digital_services",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_health",
+      },
+    },
+  ],
+  S: [
+    "<b>MSP</b> Service Locations Codes...1, 2021, the <b>MSP</b> Service Locations Codes...where publicly funded <b>MSP</b> services are provided...or tracked through\n<b>MSP</b>.\n\n(Q) Specialist Physician",
+  ],
+  LANG: [""],
+  HAS: [
+    {
+      L: [""],
+      C: [
+        {
+          $: {
+            CID: "",
+            ENC: "",
+            SZ: "120.3k",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// Services tab
+const mockResultTab4 = {
+  $: {
+    N: "1",
+  },
+  U: [
+    "https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents",
+  ],
+  UE: [
+    "https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents",
+  ],
+  T: [
+    "Medical Services Plan (MSP) for British Columbia (B.C.) Residents - Province of British Columbia",
+  ],
+  RK: ["51.4457683984405"],
+  ENT_SOURCE: [""],
+  FS: [
+    {
+      $: {
+        NAME: "date",
+        VALUE: "2020-03-31",
+      },
+    },
+  ],
+  MT: [
+    {
+      $: {
+        N: "query_id",
+        V: "2969246861271",
+      },
+    },
+    {
+      $: {
+        N: "prev_query_id",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "datasource/modificationDate",
+        V: "1585669825884",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.creator",
+        V: "Ministry of Health",
+      },
+    },
+    {
+      $: {
+        N: "security_classification",
+        V: "Low",
+      },
+    },
+    {
+      $: {
+        N: "datasource/category",
+        V: "Web",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.subject",
+        V: "Health",
+      },
+    },
+    {
+      $: {
+        N: "level1_id",
+        V: "EC75FD2ECA044D2C9CCB32361905348A",
+      },
+    },
+    {
+      $: {
+        N: "keywords",
+        V:
+          "B.C. Residents, Eligibility and Enrolment, Benefits, Premiums, Personal Health Identification, Managing your MSP Account, Contact Us",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.current_page",
+        V: "Medical Services Plan (MSP) for British Columbia (B.C.) Residents",
+      },
+    },
+    {
+      $: {
+        N: "mes:date",
+        V: "1585669825000",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.publisher",
+        V: "Province of British Columbia",
+      },
+    },
+    {
+      $: {
+        N: "title",
+        V:
+          "Medical Services Plan (MSP) for British Columbia (B.C.) Residents - Province of British Columbia",
+      },
+    },
+    {
+      $: {
+        N: "content",
+        V: "",
+      },
+    },
+    {
+      $: {
+        N: "Content-Type",
+        V: "text/html; charset=UTF-8",
+      },
+    },
+    {
+      $: {
+        N: "level2_id",
+        V: "7A3AF3683BCA48BEB6717B3B93EE6A0A",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "85A6C31BB51F4DF4932EE92D0533E250",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "A23A6FFB4CD14778B5737BD4BCBB7656",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "5061105D82B44312BB31780BA6F12984",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "0B851B2CC5B14EFE8958C45C37BE1CF5",
+      },
+    },
+    {
+      $: {
+        N: "content_group_id",
+        V: "97CA0E9AFC8847058CDA4936FA91E955",
+      },
+    },
+    {
+      $: {
+        N: "datasource/fqcategory",
+        V: "Web:mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.created",
+        V: "2015-01-08",
+      },
+    },
+    {
+      $: {
+        N: "datasource/mes:key",
+        V:
+          "https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.modified",
+        V: "2020-03-31",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.creator",
+        V: "Ministry of Health",
+      },
+    },
+    {
+      $: {
+        N: "current_page",
+        V: "Medical Services Plan (MSP) for British Columbia (B.C.) Residents",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level3",
+        V: "Medical Services Plan",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level4",
+        V: "Medical Services Plan (MSP) for British Columbia (B.C.) Residents",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level1",
+        V: "Health",
+      },
+    },
+    {
+      $: {
+        N: "DCSext.level2",
+        V: "Health & Drug Coverage",
+      },
+    },
+    {
+      $: {
+        N: "datasource/categoryinstance",
+        V: "mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "description",
+        V: "Medical Services Plan for B.C. Residents",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS.language",
+        V: "eng",
+      },
+    },
+    {
+      $: {
+        N: "level3_id",
+        V: "91C51D566CF941BAA404E4C5657399EA",
+      },
+    },
+    {
+      $: {
+        N: "collections",
+        V: "mb_gov_feed",
+      },
+    },
+    {
+      $: {
+        N: "mes:size",
+        V: "110696.0",
+      },
+    },
+    {
+      $: {
+        N: "level4",
+        V: "Medical Services Plan (MSP) for British Columbia (B.C.) Residents",
+      },
+    },
+    {
+      $: {
+        N: "current_page_id",
+        V: "239FC60D45274CA59FCDF001A2F89899",
+      },
+    },
+    {
+      $: {
+        N: "ese_enhancedSearch",
+        V: "povertySupports",
+      },
+    },
+    {
+      $: {
+        N: "ese_enhancedSearch",
+        V: "services",
+      },
+    },
+    {
+      $: {
+        N: "level1",
+        V: "Health",
+      },
+    },
+    {
+      $: {
+        N: "level3",
+        V: "Medical Services Plan",
+      },
+    },
+    {
+      $: {
+        N: "level2",
+        V: "Health & Drug Coverage",
+      },
+    },
+    {
+      $: {
+        N: "extension",
+        V: "html",
+      },
+    },
+    {
+      $: {
+        N: "security_label",
+        V: "Public ",
+      },
+    },
+    {
+      $: {
+        N: "categoryclass",
+        V: "default",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_health",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_digital_services",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_finance",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_sdsi",
+      },
+    },
+    {
+      $: {
+        N: "content_group",
+        V: "CMF_gov_health_access_health",
+      },
+    },
+    {
+      $: {
+        N: "level4_id",
+        V: "239FC60D45274CA59FCDF001A2F89899",
+      },
+    },
+    {
+      $: {
+        N: "navigaton_title",
+        V: "Medical Services Plan (MSP) for British Columbia (B.C.) Residents",
+      },
+    },
+    {
+      $: {
+        N: "MBCTERMS.subjectCategory",
+        V: "Health and Safety",
+      },
+    },
+    {
+      $: {
+        N: "DCTERMS:interactiveResource",
+        V: "Topic",
+      },
+    },
+  ],
+  S: [
+    "Health &amp; Drug Coverage <b>Medical Services Plan</b>\n     \t\tSection Navigation\n\n<b>Medical Services Plan (MSP</b>) for British Columbia...Identification\nManaging Your <b>MSP</b> Account\n<b>MSP</b> Premium Elimination: Jan. 1, 2020\n<b>Medical Services Plan</b> – British Columbia...Administrators - Contact Us\n<b>Medical Services Plan (MSP</b>) for British Columbia...your account or <b>MSP</b> benefits, please contact <b>Health Insurance</b> BC.\nContact Us",
+  ],
+  LANG: [""],
+  HAS: [
+    {
+      L: [""],
+      C: [
+        {
+          $: {
+            CID: "",
+            ENC: "",
+            SZ: "108.1k",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export { mockResultTab1, mockResultTab2, mockResultTab3, mockResultTab4 };

--- a/react-app/src/pages/Search/Result/__tests__/__snapshots__/getResultDescription.test.js.snap
+++ b/react-app/src/pages/Search/Result/__tests__/__snapshots__/getResultDescription.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getResultDescription renders a Tab 1 (All) description correctly 1`] = `
+<p
+  className="description"
+>
+  Information on both included and excluded benefits eligibility.
+</p>
+`;
+
+exports[`getResultDescription renders a Tab 2 (News) description correctly 1`] = `
+<p
+  className="description"
+>
+  As the Province eliminates Medical Service Plan (MSP) premiums for British Columbians, an updated payment method will ensure international students continue to contribute to, and benefit from, B.C.‘s health-care coverage.
+</p>
+`;
+
+exports[`getResultDescription renders a Tab 3 (Documents) description correctly 1`] = `
+<p
+  className="description"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<b>MSP</b> Service Locations Codes...1, 2021, the <b>MSP</b> Service Locations Codes...where publicly funded <b>MSP</b> services are provided...or tracked through
+<b>MSP</b>.
+
+(Q) Specialist Physician",
+    }
+  }
+/>
+`;
+
+exports[`getResultDescription renders a Tab 4 (Services) description correctly 1`] = `
+<p
+  className="description"
+>
+  Medical Services Plan for B.C. Residents
+</p>
+`;

--- a/react-app/src/pages/Search/Result/__tests__/getResultDescription.test.js
+++ b/react-app/src/pages/Search/Result/__tests__/getResultDescription.test.js
@@ -1,0 +1,38 @@
+import TestRenderer from "react-test-renderer";
+
+import getResultDescription from "../getResultDescription";
+
+import {
+  mockResultTab1,
+  mockResultTab2,
+  mockResultTab3,
+  mockResultTab4,
+} from "../__mocks__/mockResultData";
+
+describe("getResultDescription", () => {
+  const descriptionTab1 = TestRenderer.create(
+    getResultDescription(mockResultTab1, 1)
+  ).toJSON();
+  const descriptionTab2 = TestRenderer.create(
+    getResultDescription(mockResultTab2, 2)
+  ).toJSON();
+  const descriptionTab3 = TestRenderer.create(
+    getResultDescription(mockResultTab3, 3)
+  ).toJSON();
+  const descriptionTab4 = TestRenderer.create(
+    getResultDescription(mockResultTab4, 4)
+  ).toJSON();
+
+  it("renders a Tab 1 (All) description correctly", () => {
+    expect(descriptionTab1).toMatchSnapshot();
+  });
+  it("renders a Tab 2 (News) description correctly", () => {
+    expect(descriptionTab2).toMatchSnapshot();
+  });
+  it("renders a Tab 3 (Documents) description correctly", () => {
+    expect(descriptionTab3).toMatchSnapshot();
+  });
+  it("renders a Tab 4 (Services) description correctly", () => {
+    expect(descriptionTab4).toMatchSnapshot();
+  });
+});

--- a/react-app/src/pages/Search/Result/getResultDescription.js
+++ b/react-app/src/pages/Search/Result/getResultDescription.js
@@ -1,0 +1,27 @@
+export default function getResultDescription(result, tab) {
+  // Documents (3) tab
+  if (tab === 3) {
+    return (
+      <p
+        className="description"
+        dangerouslySetInnerHTML={{ __html: result?.S?.toString() }}
+      />
+    );
+
+    // All (1), Services (4), News (2) tabs and default
+  } else {
+    return (
+      <p className="description">
+        {result?.MT?.length > 0 &&
+          result?.MT?.map((metaTag) => {
+            if (metaTag?.$?.N === "description") {
+              return metaTag?.$?.V;
+            }
+            // .map() expects an explicit return value and React will
+            // throw a warning if this is not present
+            return null;
+          })}
+      </p>
+    );
+  }
+}

--- a/react-app/src/pages/Search/Result/getResultFileIcon.js
+++ b/react-app/src/pages/Search/Result/getResultFileIcon.js
@@ -1,0 +1,13 @@
+import Icon from "../../../components/Icon";
+
+export default function getResultFileIcon(mimeType) {
+  if (mimeType === "application/pdf") {
+    return <Icon id={"file-pdf-solid.svg"} />;
+  } else if (
+    mimeType ===
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  ) {
+    return <Icon id={"file-word-solid.svg"} />;
+  }
+  return null;
+}

--- a/react-app/src/pages/Search/Result/getResultTitle.js
+++ b/react-app/src/pages/Search/Result/getResultTitle.js
@@ -1,0 +1,24 @@
+export default function getResultTitle(result, tab) {
+  // All (1) or Services (4) tabs
+  if (tab === 1 || tab === 4) {
+    return (
+      <a className="title" href={result?.UE}>
+        {result?.T?.toString().split(" - Province of British Columbia", 1)[0]}
+      </a>
+    );
+    // News (2) tab
+  } else if (tab === 2) {
+    return (
+      <a className="title" href={result?.UE}>
+        {result?.T?.toString().split(" | BC Gov News", 1)[0]}
+      </a>
+    );
+    // Documents (3) tab and default
+  } else {
+    return (
+      <a className="title" href={result?.UE}>
+        {result?.T}
+      </a>
+    );
+  }
+}

--- a/react-app/src/pages/Search/Result/index.js
+++ b/react-app/src/pages/Search/Result/index.js
@@ -2,7 +2,9 @@ import PropTypes from "prop-types";
 import MediaQuery from "react-responsive";
 import styled from "styled-components";
 
-import Icon from "../../../components/Icon";
+import getResultFileIcon from "./getResultFileIcon";
+import getResultTitle from "./getResultTitle";
+import getResultDescription from "./getResultDescription";
 
 const StyledResult = styled.div`
   display: flex;
@@ -62,71 +64,6 @@ const StyledResult = styled.div`
 `;
 
 function Result({ result, tab }) {
-  function getResultFileIcon(mimeType) {
-    if (mimeType === "application/pdf") {
-      return <Icon id={"file-pdf-solid.svg"} />;
-    } else if (
-      mimeType ===
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    ) {
-      return <Icon id={"file-word-solid.svg"} />;
-    }
-    return null;
-  }
-
-  function getResultTitle(result) {
-    // All (1) or Services (4) tabs
-    if (tab === 1 || tab === 4) {
-      return (
-        <a className="title" href={result?.UE}>
-          {result?.T?.toString().split(" - Province of British Columbia", 1)[0]}
-        </a>
-      );
-      // News (2) tab
-    } else if (tab === 2) {
-      return (
-        <a className="title" href={result?.UE}>
-          {result?.T?.toString().split(" | BC Gov News", 1)[0]}
-        </a>
-      );
-      // Documents (3) tab and default
-    } else {
-      return (
-        <a className="title" href={result?.UE}>
-          {result?.T}
-        </a>
-      );
-    }
-  }
-
-  function getResultDescription(result) {
-    // Documents (3) tab
-    if (tab === 3) {
-      return (
-        <p
-          className="description"
-          dangerouslySetInnerHTML={{ __html: result?.S?.toString() }}
-        />
-      );
-
-      // All (1), Services (4), News (2) tabs and default
-    } else {
-      return (
-        <p className="description">
-          {result?.MT?.length > 0 &&
-            result?.MT?.map((metaTag) => {
-              if (metaTag?.$?.N === "description") {
-                return metaTag?.$?.V;
-              }
-              // .map() expects an explicit return value and React will
-              // throw a warning if this is not present
-              return null;
-            })}
-        </p>
-      );
-    }
-  }
-
   return (
     <StyledResult>
       {/*
@@ -139,16 +76,16 @@ function Result({ result, tab }) {
         <div className="thumbnail"></div>
         <div className="text">
           {result?.$?.MIME && getResultFileIcon(result?.$?.MIME)}
-          {getResultTitle(result)}
-          {getResultDescription(result)}
+          {getResultTitle(result, tab)}
+          {getResultDescription(result, tab)}
         </div>
       </MediaQuery>
 
       <MediaQuery minWidth={"576px"}>
         <div className="text">
           {result?.$?.MIME && getResultFileIcon(result?.$?.MIME)}
-          {getResultTitle(result)}
-          {getResultDescription(result)}
+          {getResultTitle(result, tab)}
+          {getResultDescription(result, tab)}
         </div>
         <div className="thumbnail"></div>
       </MediaQuery>


### PR DESCRIPTION
This PR breaks the functionality in the Search/Result component out into separate getter functions and starts adding tests.

- `react-test-renderer` is added as a front-end devDependency (not using Enzyme for this because it doesn't have React 17 support yet) (0054190)
- `getResultDescription()`,`getResultFileIcon()`, and `getResultTitle()` functions are broken out from the Search/Result component for testing (ced2031)
- A set of mock Result data is added with one test case for each tab type (b89f619)
- Tests are added for `getResultDescription()` with snapshots using `react-test-renderer` (6f59090)