### PR TITLE
Search Filter menu appears to the right of the results column

### DIFF
--- a/react-app/src/_services/image.service.js
+++ b/react-app/src/_services/image.service.js
@@ -44,6 +44,7 @@ import { ReactComponent as leafSolid } from "../components/assets/leaf-solid.svg
 import { ReactComponent as localGovernment } from "../components/assets/local-government.svg";
 import { ReactComponent as mapIconsLawyer } from "../components/assets/map-icons-lawyer.svg";
 import { ReactComponent as materialAccessTime } from "../components/assets/material-access-time.svg";
+import { ReactComponent as materialClose } from "../components/assets/material-close.svg";
 import { ReactComponent as materialWork } from "../components/assets/material-work.svg";
 import { ReactComponent as newspaperSolid } from "../components/assets/newspaper-solid.svg";
 import { ReactComponent as nounAntlers } from "../components/assets/noun-project-antlers.svg";
@@ -106,6 +107,7 @@ const svgIcons = {
   "local-government.svg": localGovernment,
   "map-icons-lawyer.svg": mapIconsLawyer,
   "material-access-time.svg": materialAccessTime,
+  "material-close.svg": materialClose,
   "material-work.svg": materialWork,
   "newspaper-solid.svg": newspaperSolid,
   "noun-project-antlers.svg": nounAntlers,

--- a/react-app/src/components/assets/material-close.svg
+++ b/react-app/src/components/assets/material-close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -10,6 +10,10 @@ import Icon from "../../../components/Icon";
 const StyledFilterMenu = styled.div`
   position: relative;
 
+  * {
+    font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif;
+  }
+
   button.tab {
     background: none;
     border: none;
@@ -103,7 +107,6 @@ const StyledFilterMenu = styled.div`
   }
 
   div.filters-menu {
-    border-bottom: 1px solid #d6d6d6;
     left: 100%;
     margin-left: 40px;
     max-width: 320px;
@@ -143,7 +146,6 @@ const StyledFilterMenu = styled.div`
       }
     }
 
-
     div.controls {
       align-items: flex-start;
       display: flex;
@@ -164,16 +166,32 @@ const StyledFilterMenu = styled.div`
       }
 
       div.filter-selection-group {
+        border-bottom: 1px solid #d6d6d6;
+
         button.head {
+          align-items: center;
+          background: none;
+          border: none;
+          cursor: pointer;
           display: flex;
           flex-direction: row;
+          min-height: 44px;
+          padding: 0;
           width: 320px;
 
+          :hover {
+            span.current-selection {
+              text-decoration: underline;
+            }
+          }
+
           span.title {
+            font-weight: 700;
             margin-right: auto;
           }
 
           svg {
+            margin-left: 8px;
             width: 20px;
           }
 
@@ -198,13 +216,31 @@ const StyledFilterMenu = styled.div`
               display: none;
             }
 
-            input[type=radio] {
-              /* display: none;
-              opacity: 0.01; */
-            }
+            div.input-container {
+              align-items: center;
+              display: flex;
 
-            input[type=radio]:checked+label {
-              font-weight: 700;
+              input[type=radio] {
+                cursor: pointer;
+                height: 1px;
+                opacity: 0.01;
+                width: 1px;
+              }
+
+              input[type=radio] + label {
+                cursor: pointer;
+                line-height: 44px;
+                min-height: 44px;
+
+                &:hover {
+                  text-decoration: underline;
+                }
+              }
+
+              input[type=radio]:checked + label {
+                color: #1a5a96;
+                font-weight: 700;
+              }
             }
           }
         }
@@ -294,6 +330,24 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
     initialFiltersShown || false
   );
   const [timeSelectOpen, setTimeSelectOpen] = useState(false);
+  const [timeSelectValue, setTimeSelectValue] = useState("anytime");
+
+  function getTimeSelectLabel(key) {
+    const map = {
+      "anytime": "Anytime",
+      "today": "Today",
+      "past-7-days": "Past 7 days",
+      "past-30-days": "Past 30 days",
+      "past-90-days": "Past 90 days",
+      "custom-range": "Custom Range",
+    }
+
+    return map[key];
+  }
+
+  function resetFilters() {
+    setTimeSelectValue("anytime");
+  }
 
   return (
     <StyledFilterMenu>
@@ -333,7 +387,12 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
             <p>Refine by</p>
 
             {/* TODO: Hide reset button if no filters are selected */}
-            <button id="filter-button-reset">Reset</button>
+            <button
+              id="filter-button-reset"
+              onClick={resetFilters}
+            >
+              Reset
+            </button>
           </div>
 
           {/* Control buttons/dropdowns */}
@@ -347,7 +406,9 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                 onClick={() => setTimeSelectOpen(!timeSelectOpen)}
               >
                 <span className="title">Date:</span>
-                <span className="current-selection">Anytime</span>
+                <span className="current-selection">
+                  {getTimeSelectLabel(timeSelectValue)}
+                </span>
                 {timeSelectOpen ? (
                   <Icon id={"ionic-ios-arrow-up.svg"} />
                 ) : (
@@ -359,89 +420,112 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                   <legend id="legend-time-select">Select a time range</legend>
 
                   {/* Anytime */}
-                  <input
-                    type="radio"
-                    id="time-select-anytime"
-                    name="time-select"
-                    value="anytime"
-                    checked={true}
-                  />
-                  <label
-                    htmlFor="time-select-anytime"
-                  >
-                    Anytime
-                  </label>
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-anytime"
+                      name="time-select"
+                      value="anytime"
+                      checked={timeSelectValue === "anytime"}
+                      onChange={() => setTimeSelectValue("anytime")}
+                    />
+                    <label
+                      htmlFor="time-select-anytime"
+                    >
+                      {getTimeSelectLabel("anytime")}
+                    </label>
+                  </div>
 
                   {/* Today */}
-                  <input
-                    type="radio"
-                    id="time-select-today"
-                    name="time-select"
-                    value="today"
-                  />
-                  <label
-                    htmlFor="time-select-today"
-                  >
-                    Today
-                  </label>
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-today"
+                      name="time-select"
+                      value="today"
+                      checked={timeSelectValue === "today"}
+                      onChange={() => setTimeSelectValue("today")}
+                    />
+                    <label
+                      htmlFor="time-select-today"
+                    >
+                      {getTimeSelectLabel("today")}
+                    </label>
+                  </div>
 
                   {/* Past 7 Days */}
-                  <input
-                    type="radio"
-                    id="time-select-past-7-days"
-                    name="time-select"
-                    value="past-7-days"
-                  />
-                  <label
-                    htmlFor="time-select-past-7-days"
-                  >
-                    Past 7 days
-                  </label>
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-past-7-days"
+                      name="time-select"
+                      value="past-7-days"
+                      checked={timeSelectValue === "past-7-days"}
+                      onChange={() => setTimeSelectValue("past-7-days")}
+                    />
+                    <label
+                      htmlFor="time-select-past-7-days"
+                    >
+                      {getTimeSelectLabel("past-7-days")}
+                    </label>
+                  </div>
 
                   {/* Past 30 Days */}
-                  <input
-                    type="radio"
-                    id="time-select-past-30-days"
-                    name="time-select"
-                    value="past-30-days"
-                  />
-                  <label
-                    htmlFor="time-select-past-30-days"
-                  >
-                    Past 30 days
-                  </label>
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-past-30-days"
+                      name="time-select"
+                      value="past-30-days"
+                      checked={timeSelectValue === "past-30-days"}
+                      onChange={() => setTimeSelectValue("past-30-days")}
+                    />
+                    <label
+                      htmlFor="time-select-past-30-days"
+                    >
+                      {getTimeSelectLabel("past-30-days")}
+                    </label>
+                  </div>
 
                   {/* Past 90 Days */}
-                  <input
-                    type="radio"
-                    id="time-select-past-90-days"
-                    name="time-select"
-                    value="past-90-days"
-                  />
-                  <label
-                    htmlFor="time-select-past-90-days"
-                  >
-                    Past 90 days
-                  </label>
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-past-90-days"
+                      name="time-select"
+                      value="past-90-days"
+                      checked={timeSelectValue === "past-90-days"}
+                      onChange={() => setTimeSelectValue("past-90-days")}
+                    />
+                    <label
+                      htmlFor="time-select-past-90-days"
+                    >
+                      {getTimeSelectLabel("past-90-days")}
+                    </label>
+                  </div>
 
-                  {/* Past 90 Days */}
-                  <input
-                    type="radio"
-                    id="time-select-custom-range"
-                    name="time-select"
-                    value="custom-range"
-                  />
-                  <label
-                    htmlFor="time-select-custom-range"
-                  >
-                    Custom Range
-                  </label>
+                  {/* Custom Range */}
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="time-select-custom-range"
+                      name="time-select"
+                      value="custom-range"
+                      checked={timeSelectValue === "custom-range"}
+                      onChange={() => setTimeSelectValue("custom-range")}
+                    />
+                    <label
+                      htmlFor="time-select-custom-range"
+                    >
+                      {getTimeSelectLabel("custom-range")}
+                    </label>
+                  </div>
 
                 </fieldset>
               </div>}
             </div>
 
-            <Dropdown
+            {/* <Dropdown
               id={"search-sort"}
               label={"Sort by"}
               options={[
@@ -453,11 +537,11 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                 },
               ]}
             />
-            <button id="reset-filters">Reset filters</button>
+            <button id="reset-filters">Reset filters</button> */}
           </div>
 
           {/* Facets checkboxes */}
-          {facets?.length > 0 && (
+          {/* {facets?.length > 0 && (
             <div className="facets-container">
               {facets.map((facet, index) => {
                 return (
@@ -491,7 +575,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                 );
               })}
             </div>
-          )}
+          )} */}
         </div>
       )}
     </StyledFilterMenu>

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -35,8 +35,8 @@ const StyledFilterMenu = styled.div`
     @media (max-width: 768px) {
       margin: 0 7px;
 
-      /* On mobile, the More Filters button becomes a funnel icon */
-      &#more-filters {
+      /* On mobile, the Filters button becomes a funnel icon */
+      &#filters {
         border-bottom: 5px solid transparent;
         height: 44px;
         width: 44px;
@@ -83,7 +83,7 @@ const StyledFilterMenu = styled.div`
     }
   }
 
-  div.more-filters-menu {
+  div.filters-menu {
     border-bottom: 1px solid #d6d6d6;
 
     div.controls {
@@ -184,8 +184,10 @@ const StyledFilterMenu = styled.div`
   }
 `;
 
-function FilterMenu({ facets, parentCallback, tab }) {
-  const [moreFiltersShown, setMoreFiltersShown] = useState(false);
+function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
+  const [filtersShown, setFiltersShown] = useState(
+    initialFiltersShown || false
+  );
 
   return (
     <StyledFilterMenu>
@@ -203,20 +205,20 @@ function FilterMenu({ facets, parentCallback, tab }) {
           );
         })}
         <button
-          id="more-filters"
-          aria-label="More Filters"
-          className={moreFiltersShown ? "active" : null}
-          onClick={() => setMoreFiltersShown(!moreFiltersShown)}
+          id="filters"
+          aria-label="Filters"
+          className={filtersShown ? "active" : null}
+          onClick={() => setFiltersShown(!filtersShown)}
         >
           <MediaQuery maxWidth={"768px"}>
             <Icon id={"filter-solid.svg"} />
           </MediaQuery>
-          <MediaQuery minWidth={"769px"}>More Filters</MediaQuery>
+          <MediaQuery minWidth={"769px"}>Filters</MediaQuery>
         </button>
       </div>
 
-      {moreFiltersShown && (
-        <div className="more-filters-menu">
+      {filtersShown && (
+        <div className="filters-menu">
           {/* Control buttons/dropdowns */}
           <div className="controls">
             <Dropdown
@@ -302,6 +304,7 @@ function FilterMenu({ facets, parentCallback, tab }) {
 
 FilterMenu.propTypes = {
   facets: PropTypes.array,
+  initialFiltersShown: PropTypes.bool,
   parentCallback: PropTypes.func.isRequired,
   tab: PropTypes.number.isRequired,
 };

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import MediaQuery from "react-responsive";
 
 import tabMap from "../tabMap";
-import Dropdown from "../../../components/Dropdown";
 import Icon from "../../../components/Icon";
 
 const StyledFilterMenu = styled.div`
@@ -212,6 +211,12 @@ const StyledFilterMenu = styled.div`
               outline: 4px solid #3b99fc;
             }
 
+            &.fieldset--facet {
+              &:focus-within {
+                outline: none;
+              }
+            }
+
             legend {
               display: none;
             }
@@ -242,80 +247,50 @@ const StyledFilterMenu = styled.div`
                 font-weight: 700;
               }
             }
-          }
-        }
-      }
-    }
 
-    div.facets-container {
-      fieldset {
-        border: none;
-        margin: 0 0 12px 0;
-        padding: 12px 0;
-        width: 100%;
-
-        legend {
-          font-size: 18px;
-          font-weight: 700;
-        }
-
-        div.facet {
-          align-items: top;
-          display: flex;
-          flex-direction: row;
-          flex-wrap: wrap;
-          gap: 10px;
-
-          div.facet-category {
-            align-items: top;
-            display: flex;
-            flex-direction: row;
-            vertical-align: top;
-            width: calc((100% / 3) - (20px / 3)); // One third of total with gap
-
-            @media (max-width: 768px) {
-              width: calc(50% - 5px); // Half of total with gap
-            }
-            @media (max-width: 576px) {
-              width: 100%;
-            }
-
-            /* Checkbox box aspect */
-            input[type="checkbox"]:not(:checked):before,
-            input[type="checkbox"]:checked:before {
-              background: white;
-              border: 1px solid #606060;
-              content: "";
-              display: inline-block;
-              height: 20px;
-              width: 20px;
-            }
-
-            /* Checkbox checkmark aspect */
-            input[type="checkbox"]:checked:before {
-              color: #313132;
-              content: "";
-              background-color: #606060;
-              background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='check' class='svg-inline--fa fa-check fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23FFFFFF' d='M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z'%3E%3C/path%3E%3C/svg%3E%0A"); // FontAwesome check-solid in white
-              background-position-x: 1px;
-              background-position-y: 1px;
-              background-repeat: no-repeat;
-              background-size: 16px 16px;
-            }
-
-            label {
-              color: #313132;
-              cursor: pointer;
+            div.facet-category {
+              align-items: top;
               display: flex;
-              font-size: 18px;
-              padding: 8px 8px 8px 0;
+              flex-direction: row;
+              vertical-align: top;
 
-              span {
-                margin-left: 30px;
+              /* Checkbox box aspect */
+              input[type="checkbox"]:not(:checked):before,
+              input[type="checkbox"]:checked:before {
+                background: white;
+                border: 1px solid #606060;
+                content: "";
+                display: inline-block;
+                height: 20px;
+                width: 20px;
               }
 
-              &:focus-within {
-                outline: 4px solid #3b99fc;
+              /* Checkbox checkmark aspect */
+              input[type="checkbox"]:checked:before {
+                color: #313132;
+                content: "";
+                background-color: #606060;
+                background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='check' class='svg-inline--fa fa-check fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%23FFFFFF' d='M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z'%3E%3C/path%3E%3C/svg%3E%0A"); // FontAwesome check-solid in white
+                background-position-x: 1px;
+                background-position-y: 1px;
+                background-repeat: no-repeat;
+                background-size: 16px 16px;
+              }
+
+              label {
+                color: #313132;
+                cursor: pointer;
+                display: flex;
+                font-size: 18px;
+                padding: 8px 8px 8px 0;
+
+                span {
+                  margin-left: 30px;
+                }
+
+                &:focus-within {
+                  outline: 4px solid #3b99fc;
+                }
               }
             }
           }
@@ -333,6 +308,8 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
   const [timeSelectValue, setTimeSelectValue] = useState("anytime");
   const [sortSelectOpen, setSortSelectOpen] = useState(false);
   const [sortSelectValue, setSortSelectValue] = useState("best-match");
+  const [facetsOpen, setFacetsOpen] = useState([]);
+  const [facetCategoriesSelected, setFacetCategoriesSelected] = useState([]);
 
   function getTimeSelectLabel(key) {
     const map = {
@@ -356,9 +333,33 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
     return map[key];
   }
 
+  function handleFacetButtonToggle(index) {
+    const currentFacetsOpen = [...facetsOpen];
+
+    // If the index is in the open facets array, remove it. Otherwise, add it.
+    if (currentFacetsOpen.includes(index)) {
+      setFacetsOpen(currentFacetsOpen.filter(f => f !== index));
+    } else {
+      setFacetsOpen([index, ...currentFacetsOpen]);
+    }
+  }
+
+  function handleFacetCategorySelection(index, cIndex, event) {
+    const currentFacetCategoriesSelected = [...facetCategoriesSelected]
+
+    if (event.target.checked) {
+      setFacetCategoriesSelected([`${index}-${cIndex}`, ...currentFacetCategoriesSelected]);
+    } else {
+      setFacetCategoriesSelected(
+        currentFacetCategoriesSelected.filter(fc => fc !== `${index}-${cIndex}`)
+      );
+    }
+  }
+
   function resetFilters() {
     setTimeSelectValue("anytime");
     setSortSelectValue("best-match");
+    setFacetCategoriesSelected([]);
   }
 
   return (
@@ -595,44 +596,65 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                 </fieldset>
               </div>}
             </div>
-          </div>
 
-          {/* Facets checkboxes */}
-          {/* {facets?.length > 0 && (
-            <div className="facets-container">
-              {facets.map((facet, index) => {
+            {/* Facet group filters */}
+            {facets?.length > 0 &&
+              facets.map((facet, index) => {
                 return (
-                  <fieldset key={`facet-${index}`}>
-                    {facet?.facet && <legend>{facet.facet}</legend>}
-                    {facet?.categories?.length > 0 && (
-                      <div className="facet">
-                        {facet.categories.map((category, cIndex) => {
-                          return (
-                            <div
-                              key={`facet-${index}-category-${cIndex}`}
-                              className="facet-category"
-                            >
-                              <label htmlFor={`facet-checkbox-${cIndex}`}>
-                                <input
-                                  type="checkbox"
-                                  id={`facet-checkbox-${cIndex}`}
-                                  name={`facet-checkbox-${cIndex}`}
-                                  value={`${index}-${cIndex}`}
-                                />
-                                <span>
-                                  {category?.name} ({category?.count})
-                                </span>
-                              </label>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </fieldset>
+                  <div
+                    key={`filter-selection-group-facet-${index}`}
+                    className="filter-selection-group"
+                  >
+                    <button
+                      className="head"
+                      aria-label={facet.facet}
+                      onClick={() => handleFacetButtonToggle(index)}
+                    >
+                      <span className="title">{facet.facet}</span>
+                      {facetsOpen.includes(index) ? (
+                        <Icon id={"ionic-ios-arrow-up.svg"} />
+                      ) : (
+                        <Icon id={"ionic-ios-arrow-down.svg"} />
+                      )}
+                    </button>
+                    {facetsOpen.includes(index) && <div className="body">
+                      <fieldset className="fieldset--facet">
+                        {facet?.facet && <legend>{facet.facet}</legend>}
+                        {facet?.categories?.length > 0 && (
+                          <div className="facet">
+                            {facet.categories.map((category, cIndex) => {
+                              return (
+                                <div
+                                  key={`facet-${index}-category-${cIndex}`}
+                                  className="facet-category"
+                                >
+                                  <label htmlFor={`facet-checkbox-${index}-${cIndex}`}>
+                                    <input
+                                      type="checkbox"
+                                      id={`facet-checkbox-${index}-${cIndex}`}
+                                      name={`facet-checkbox-${index}-${cIndex}`}
+                                      value={`${index}-${cIndex}`}
+                                      checked={facetCategoriesSelected.includes(`${index}-${cIndex}`)}
+                                      onChange={(e) => {
+                                        handleFacetCategorySelection(index, cIndex, e);
+                                      }}
+                                    />
+                                    <span>
+                                      {category?.name} ({category?.count})
+                                    </span>
+                                  </label>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </fieldset>
+                    </div>}
+                  </div>
                 );
-              })}
-            </div>
-          )} */}
+              })
+            }
+          </div>
         </div>
       )}
     </StyledFilterMenu>

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -110,7 +110,7 @@ const StyledFilterMenu = styled.div`
     position: absolute;
     top: 0;
 
-    div.refinements {
+    div.filter-top-controls {
       display: flex;
       flex-direction: row;
       align-items: baseline;
@@ -147,7 +147,7 @@ const StyledFilterMenu = styled.div`
     div.controls {
       align-items: flex-start;
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       margin: 0 0 12px 0;
 
       button,
@@ -160,6 +160,53 @@ const StyledFilterMenu = styled.div`
 
         &:last-child {
           margin-right: 0;
+        }
+      }
+
+      div.filter-selection-group {
+        button.head {
+          display: flex;
+          flex-direction: row;
+          width: 320px;
+
+          span.title {
+            margin-right: auto;
+          }
+
+          svg {
+            width: 20px;
+          }
+
+          :focus {
+            outline: 4px solid #3b99fc;
+          }
+        }
+        div.body {
+          fieldset {
+            border: none;
+            display: flex;
+            flex-direction: column;
+            margin: 0;
+            max-width: 320px;
+            padding: 0;
+
+            :focus-within {
+              outline: 4px solid #3b99fc;
+            }
+
+            legend {
+              display: none;
+            }
+
+            input[type=radio] {
+              /* display: none;
+              opacity: 0.01; */
+            }
+
+            input[type=radio]:checked+label {
+              font-weight: 700;
+            }
+          }
         }
       }
     }
@@ -246,6 +293,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
   const [filtersShown, setFiltersShown] = useState(
     initialFiltersShown || false
   );
+  const [timeSelectOpen, setTimeSelectOpen] = useState(false);
 
   return (
     <StyledFilterMenu>
@@ -280,38 +328,119 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
 
       {filtersShown && (
         <div className="filters-menu">
-          {/* Refinements control */}
-          <div className="refinements">
+          {/* Label and reset button */}
+          <div className="filter-top-controls">
             <p>Refine by</p>
+
+            {/* TODO: Hide reset button if no filters are selected */}
             <button id="filter-button-reset">Reset</button>
           </div>
 
           {/* Control buttons/dropdowns */}
           <div className="controls">
-            <Dropdown
-              id={"search-time-range"}
-              label={"Time range"}
-              options={[
-                {
-                  label: "Anytime",
-                },
-                {
-                  label: "Today",
-                },
-                {
-                  label: "Past 7 days",
-                },
-                {
-                  label: "Past 30 days",
-                },
-                {
-                  label: "Past 90 days",
-                },
-                {
-                  label: "Custom range",
-                },
-              ]}
-            />
+
+            {/* Time period filter */}
+            <div className="filter-selection-group">
+              <button
+                className="head"
+                aria-label="Date: Anytime"
+                onClick={() => setTimeSelectOpen(!timeSelectOpen)}
+              >
+                <span className="title">Date:</span>
+                <span className="current-selection">Anytime</span>
+                {timeSelectOpen ? (
+                  <Icon id={"ionic-ios-arrow-up.svg"} />
+                ) : (
+                  <Icon id={"ionic-ios-arrow-down.svg"} />
+                )}
+              </button>
+              {timeSelectOpen && <div className="body">
+                <fieldset aria-labelledby="legend-time-select">
+                  <legend id="legend-time-select">Select a time range</legend>
+
+                  {/* Anytime */}
+                  <input
+                    type="radio"
+                    id="time-select-anytime"
+                    name="time-select"
+                    value="anytime"
+                    checked={true}
+                  />
+                  <label
+                    htmlFor="time-select-anytime"
+                  >
+                    Anytime
+                  </label>
+
+                  {/* Today */}
+                  <input
+                    type="radio"
+                    id="time-select-today"
+                    name="time-select"
+                    value="today"
+                  />
+                  <label
+                    htmlFor="time-select-today"
+                  >
+                    Today
+                  </label>
+
+                  {/* Past 7 Days */}
+                  <input
+                    type="radio"
+                    id="time-select-past-7-days"
+                    name="time-select"
+                    value="past-7-days"
+                  />
+                  <label
+                    htmlFor="time-select-past-7-days"
+                  >
+                    Past 7 days
+                  </label>
+
+                  {/* Past 30 Days */}
+                  <input
+                    type="radio"
+                    id="time-select-past-30-days"
+                    name="time-select"
+                    value="past-30-days"
+                  />
+                  <label
+                    htmlFor="time-select-past-30-days"
+                  >
+                    Past 30 days
+                  </label>
+
+                  {/* Past 90 Days */}
+                  <input
+                    type="radio"
+                    id="time-select-past-90-days"
+                    name="time-select"
+                    value="past-90-days"
+                  />
+                  <label
+                    htmlFor="time-select-past-90-days"
+                  >
+                    Past 90 days
+                  </label>
+
+                  {/* Past 90 Days */}
+                  <input
+                    type="radio"
+                    id="time-select-custom-range"
+                    name="time-select"
+                    value="custom-range"
+                  />
+                  <label
+                    htmlFor="time-select-custom-range"
+                  >
+                    Custom Range
+                  </label>
+
+                </fieldset>
+              </div>}
+            </div>
+
             <Dropdown
               id={"search-sort"}
               label={"Sort by"}

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -10,7 +10,7 @@ import Icon from "../../../components/Icon";
 const StyledFilterMenu = styled.div`
   position: relative;
 
-  button {
+  button.tab {
     background: none;
     border: none;
     border-bottom: 5px solid transparent;
@@ -110,12 +110,39 @@ const StyledFilterMenu = styled.div`
     position: absolute;
     top: 0;
 
-    p.filter-menu-label {
-      color: #003366;
-      font-size: 24px;
-      font-weight: 700;
-      margin-top: 0;
+    div.refinements {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+
+      p {
+        color: #003366;
+        font-size: 24px;
+        font-weight: 700;
+        margin: 0;
+      }
+
+      button#filter-button-reset {
+        background: none;
+        border: none;
+        color: #003366;
+        cursor: pointer;
+        font-size: 18px;
+        height: 44px;
+        margin: 0;
+        padding: 0;
+
+        :focus {
+          outline: 4px solid #3b99fc;
+        }
+
+        :hover {
+          text-decoration: underline;
+        }
+      }
     }
+
 
     div.controls {
       align-items: flex-start;
@@ -228,7 +255,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
             <button
               key={`filter-menu-button-${index}`}
               id={`filter-button-${tabButton.id}`}
-              className={tab === tabButton.index ? "active" : null}
+              className={tab === tabButton.index ? "tab active" : "tab"}
               onClick={(e) => parentCallback(e, tabButton.index)}
             >
               {tabButton.label}
@@ -238,7 +265,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
         <button
           id="filter-button-filters"
           aria-label="Filters"
-          className={filtersShown ? "active" : null}
+          className={filtersShown ? "tab active" : "tab"}
           onClick={() => setFiltersShown(!filtersShown)}
         >
           <MediaQuery maxWidth={"768px"}>
@@ -253,8 +280,11 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
 
       {filtersShown && (
         <div className="filters-menu">
-          {/* Filter menu label text */}
-          <p className="filter-menu-label">Refine by</p>
+          {/* Refinements control */}
+          <div className="refinements">
+            <p>Refine by</p>
+            <button id="filter-button-reset">Reset</button>
+          </div>
 
           {/* Control buttons/dropdowns */}
           <div className="controls">

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -8,6 +8,8 @@ import Dropdown from "../../../components/Dropdown";
 import Icon from "../../../components/Icon";
 
 const StyledFilterMenu = styled.div`
+    position: relative;
+
   button {
     background: none;
     border: none;
@@ -85,6 +87,18 @@ const StyledFilterMenu = styled.div`
 
   div.filters-menu {
     border-bottom: 1px solid #d6d6d6;
+    left: 100%;
+    margin-left: 40px;
+    max-width: 320px;
+    position: absolute;
+    top: 0;
+
+    p.filter-menu-label {
+      color: #003366;
+      font-size: 24px;
+      font-weight: 700;
+      margin-top: 0;
+    }
 
     div.controls {
       align-items: flex-start;
@@ -219,6 +233,9 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
 
       {filtersShown && (
         <div className="filters-menu">
+          {/* Filter menu label text */}
+          <p className="filter-menu-label">Refine by</p>
+
           {/* Control buttons/dropdowns */}
           <div className="controls">
             <Dropdown

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -8,7 +8,7 @@ import Dropdown from "../../../components/Dropdown";
 import Icon from "../../../components/Icon";
 
 const StyledFilterMenu = styled.div`
-    position: relative;
+  position: relative;
 
   button {
     background: none;
@@ -34,11 +34,28 @@ const StyledFilterMenu = styled.div`
       text-decoration: underline;
     }
 
+    &#filter-button-filters {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      svg {
+        color: #313132;
+        height: 32px;
+        margin: 5px 5px 0 5px;
+        width: 32px;
+      }
+
+      &.active {
+        border-color: transparent;
+      }
+    }
+
     @media (max-width: 768px) {
       margin: 0 7px;
 
       /* On mobile, the Filters button becomes a funnel icon */
-      &#filters {
+      &#filter-button-filters {
         border-bottom: 5px solid transparent;
         height: 44px;
         width: 44px;
@@ -219,7 +236,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
           );
         })}
         <button
-          id="filters"
+          id="filter-button-filters"
           aria-label="Filters"
           className={filtersShown ? "active" : null}
           onClick={() => setFiltersShown(!filtersShown)}
@@ -227,7 +244,10 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
           <MediaQuery maxWidth={"768px"}>
             <Icon id={"filter-solid.svg"} />
           </MediaQuery>
-          <MediaQuery minWidth={"769px"}>Filters</MediaQuery>
+          <MediaQuery minWidth={"769px"}>
+            {filtersShown && <Icon id={"material-close.svg"} />}
+            <span>Filters</span>
+          </MediaQuery>
         </button>
       </div>
 

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -331,6 +331,8 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
   );
   const [timeSelectOpen, setTimeSelectOpen] = useState(false);
   const [timeSelectValue, setTimeSelectValue] = useState("anytime");
+  const [sortSelectOpen, setSortSelectOpen] = useState(false);
+  const [sortSelectValue, setSortSelectValue] = useState("best-match");
 
   function getTimeSelectLabel(key) {
     const map = {
@@ -345,8 +347,18 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
     return map[key];
   }
 
+  function getSortSelectLabel(key) {
+    const map = {
+      "best-match": "Best Match",
+      "most-recent": "Most Recent",
+    }
+
+    return map[key];
+  }
+
   function resetFilters() {
     setTimeSelectValue("anytime");
+    setSortSelectValue("best-match");
   }
 
   return (
@@ -402,7 +414,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
             <div className="filter-selection-group">
               <button
                 className="head"
-                aria-label="Date: Anytime"
+                aria-label={`Date: ${getTimeSelectLabel(timeSelectValue)}`}
                 onClick={() => setTimeSelectOpen(!timeSelectOpen)}
               >
                 <span className="title">Date:</span>
@@ -525,19 +537,64 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
               </div>}
             </div>
 
-            {/* <Dropdown
-              id={"search-sort"}
-              label={"Sort by"}
-              options={[
-                {
-                  label: "Sort by best match",
-                },
-                {
-                  label: "Sort by most recent",
-                },
-              ]}
-            />
-            <button id="reset-filters">Reset filters</button> */}
+            {/* Sort by filter */}
+            <div className="filter-selection-group">
+              <button
+                className="head"
+                aria-label={`Sort by: ${getSortSelectLabel(sortSelectValue)}`}
+                onClick={() => setSortSelectOpen(!sortSelectOpen)}
+              >
+                <span className="title">Sort by:</span>
+                <span className="current-selection">
+                  {getSortSelectLabel(sortSelectValue)}
+                </span>
+                {sortSelectOpen ? (
+                  <Icon id={"ionic-ios-arrow-up.svg"} />
+                ) : (
+                  <Icon id={"ionic-ios-arrow-down.svg"} />
+                )}
+              </button>
+              {sortSelectOpen && <div className="body">
+                <fieldset aria-labelledby="legend-sort-select">
+                  <legend id="legend-sort-select">Select how to search results</legend>
+
+                  {/* Best match */}
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="sort-select-best-match"
+                      name="sort-select"
+                      value="best-match"
+                      checked={sortSelectValue === "best-match"}
+                      onChange={() => setSortSelectValue("best-match")}
+                    />
+                    <label
+                      htmlFor="sort-select-best-match"
+                    >
+                      {getSortSelectLabel("best-match")}
+                    </label>
+                  </div>
+
+                  {/* Most recent */}
+                  <div className="input-container">
+                    <input
+                      type="radio"
+                      id="sort-select-most-recent"
+                      name="sort-select"
+                      value="most-recent"
+                      checked={sortSelectValue === "most-recent"}
+                      onChange={() => setSortSelectValue("most-recent")}
+                    />
+                    <label
+                      htmlFor="sort-select-most-recent"
+                    >
+                      {getSortSelectLabel("most-recent")}
+                    </label>
+                  </div>
+
+                </fieldset>
+              </div>}
+            </div>
           </div>
 
           {/* Facets checkboxes */}

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -268,6 +268,11 @@ function Search() {
         parentCallback={updateNewQuery}
       />
 
+      {/* Filter menu */}
+      {query && (
+        <FilterMenu facets={facets} parentCallback={submitNewQuery} tab={tab} />
+      )}
+
       {/* Count of results found */}
       {resultsCount > 0 && (
         <p className="results-found">
@@ -275,11 +280,6 @@ function Search() {
           <strong>{new Intl.NumberFormat().format(resultsCount)}</strong>{" "}
           results
         </p>
-      )}
-
-      {/* Filter menu */}
-      {query && (
-        <FilterMenu facets={facets} parentCallback={submitNewQuery} tab={tab} />
       )}
 
       {/* List of results if applicable */}


### PR DESCRIPTION
This PR refactors the Search/FilterMenu component to appear to the right of the search results central column on desktop viewports to match the [GNG Phase 1 wireframes](https://xd.adobe.com/view/d27707ea-6827-45c4-9030-2586360dbd8d-8724/screen/76f69ab1-809a-40cc-9883-164a4b234e72).

<img width="1680" alt="Screenshot of Search results page with FilterMenu component open" src="https://user-images.githubusercontent.com/25143706/122625145-6bd8c580-d058-11eb-9a22-5f8cd2789ab2.png">

Currently, the controls in the FilterMenu update the state of the component itself, but there is no callback to the parent Search page to implement the filtering of results yet.

Also:
- `material-close.svg` icon is added to the image service (f7bf38b)