### PR TITLE
Enable date display in Search/Result component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - 14
+before_install:
+- export TZ=America/Vancouver

--- a/react-app/src/_utils/__tests__/getDate.test.js
+++ b/react-app/src/_utils/__tests__/getDate.test.js
@@ -1,0 +1,13 @@
+import getDate from "../getDate";
+
+describe("getDate.iso8601Extended", () => {
+  it("returns a date in YYYY-MM-DD format when given a number", () => {
+    expect(getDate.iso8601Extended(1545166174000)).toBe("2018-12-18");
+  });
+  it("returns a date in YYYY-MM-DD format when given a string", () => {
+    expect(getDate.iso8601Extended("1619835166000")).toBe("2021-04-30");
+  });
+  it("returns a date in YYYY-MM-DD format with leading zeros for month and day", () => {
+    expect(getDate.iso8601Extended(1622530800000)).toBe("2021-06-01");
+  })
+});

--- a/react-app/src/_utils/getDate.js
+++ b/react-app/src/_utils/getDate.js
@@ -1,0 +1,16 @@
+/**
+ * Given a Unix millisecond timestamp, return an ISO 8601 Extended date
+ * in the form (YYYY-MM-DD)
+ * @param {number} unixMs
+ * @returns String date in the form YYYY-MM-DD
+ */
+function iso8601Extended(unixMs) {
+  const date = new Date(parseInt(unixMs));
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // getMonth() is zero-indexed
+  const day = date.getDate();
+
+  return `${year}-${month < 10 ? "0" + month : month}-${day < 10 ? "0" + day : day}`;
+}
+
+export default { iso8601Extended };

--- a/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
+++ b/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
@@ -20,6 +20,10 @@ const StyledDateRangePicker = styled.div`
 
     input {
       font-size: 18px;
+
+      &:focus {
+        outline: 4px solid #3b99fc;
+      }
     }
 
     div.react-datepicker-wrapper {

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -153,6 +153,14 @@ const StyledFilterMenu = styled.div`
       flex-direction: column;
       margin: 0 0 12px 0;
 
+      div.filter-radio-group {
+        button.head:hover {
+          span.title {
+            text-decoration: underline;
+          }
+        }
+      }
+
       div.filter-selection-group {
         border-bottom: 1px solid #d6d6d6;
 
@@ -196,10 +204,6 @@ const StyledFilterMenu = styled.div`
             max-width: 320px;
             padding: 0;
 
-            :focus-within {
-              outline: 4px solid #3b99fc;
-            }
-
             &.fieldset--facet {
               &:focus-within {
                 outline: none;
@@ -235,6 +239,10 @@ const StyledFilterMenu = styled.div`
               input[type="radio"]:checked + label {
                 color: #1a5a96;
                 font-weight: 700;
+              }
+
+              &:focus-within {
+                outline: 4px solid #3b99fc;
               }
             }
 
@@ -593,7 +601,7 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
                 return (
                   <div
                     key={`filter-selection-group-facet-${index}`}
-                    className="filter-selection-group"
+                    className="filter-selection-group filter-radio-group"
                   >
                     <button
                       className="head"

--- a/react-app/src/pages/Search/FilterMenu/index.js
+++ b/react-app/src/pages/Search/FilterMenu/index.js
@@ -352,8 +352,11 @@ function FilterMenu({ facets, initialFiltersShown, parentCallback, tab }) {
 
   function resetFilters() {
     setTimeSelectValue("anytime");
+    setTimeSelectOpen(false);
     setSortSelectValue("best-match");
+    setSortSelectOpen(false);
     setFacetCategoriesSelected([]);
+    setFacetsOpen([]);
   }
 
   return (

--- a/react-app/src/pages/Search/Result/__tests__/__snapshots__/getResultDate.test.js.snap
+++ b/react-app/src/pages/Search/Result/__tests__/__snapshots__/getResultDate.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getResultDate renders a Tab 1 (All) date correctly 1`] = `
+<p
+  className="date"
+>
+  <strong>
+    Published date:
+  </strong>
+   
+  2018-12-18
+</p>
+`;
+
+exports[`getResultDate renders a Tab 2 (News) date correctly 1`] = `
+<p
+  className="date"
+>
+  <strong>
+    Published date:
+  </strong>
+   
+  2019-08-01
+</p>
+`;
+
+exports[`getResultDate renders a Tab 3 (Documents) date correctly 1`] = `
+<p
+  className="date"
+>
+  <strong>
+    Published date:
+  </strong>
+   
+  2021-03-24
+</p>
+`;
+
+exports[`getResultDate renders a Tab 4 (Services) date correctly 1`] = `
+<p
+  className="date"
+>
+  <strong>
+    Published date:
+  </strong>
+   
+  2020-03-31
+</p>
+`;

--- a/react-app/src/pages/Search/Result/__tests__/getResultDate.test.js
+++ b/react-app/src/pages/Search/Result/__tests__/getResultDate.test.js
@@ -1,0 +1,38 @@
+import TestRenderer from "react-test-renderer";
+
+import getResultDate from "../getResultDate";
+
+import {
+  mockResultTab1,
+  mockResultTab2,
+  mockResultTab3,
+  mockResultTab4,
+} from "../__mocks__/mockResultData";
+
+describe("getResultDate", () => {
+  const dateTab1 = TestRenderer.create(
+    getResultDate(mockResultTab1)
+  ).toJSON();
+  const dateTab2 = TestRenderer.create(
+    getResultDate(mockResultTab2)
+  ).toJSON();
+  const dateTab3 = TestRenderer.create(
+    getResultDate(mockResultTab3)
+  ).toJSON();
+  const dateTab4 = TestRenderer.create(
+    getResultDate(mockResultTab4)
+  ).toJSON();
+
+  it("renders a Tab 1 (All) date correctly", () => {
+    expect(dateTab1).toMatchSnapshot();
+  });
+  it("renders a Tab 2 (News) date correctly", () => {
+    expect(dateTab2).toMatchSnapshot();
+  });
+  it("renders a Tab 3 (Documents) date correctly", () => {
+    expect(dateTab3).toMatchSnapshot();
+  });
+  it("renders a Tab 4 (Services) date correctly", () => {
+    expect(dateTab4).toMatchSnapshot();
+  });
+})

--- a/react-app/src/pages/Search/Result/getResultDate.js
+++ b/react-app/src/pages/Search/Result/getResultDate.js
@@ -1,0 +1,48 @@
+import getDate from "../../../_utils/getDate";
+
+// Return a result's date in YYYY-MM-DD format
+export default function getResultDate(result) {
+  let date = "";
+
+  // Prefer the <FS name="date" /> node if available
+  if (result?.FS?.length > 0) {
+    result?.FS?.forEach((detail) => {
+      if (detail?.$?.NAME === "date") {
+        date = detail?.$?.VALUE;
+      }
+    })
+  }
+
+  // Or try <MT N="DCTERMS.modified" />
+  if (!date && result?.MT?.length > 0) {
+    result?.MT?.forEach((metaTag) => {
+      if (metaTag?.$?.N === "DCTERMS.modified") {
+        date = metaTag?.$?.V;
+      }
+    })
+  }
+
+  // Or try <MT N="datasource/modificationDate" />
+  if (!date && result?.MT?.length > 0) {
+    result?.MT?.forEach((metaTag) => {
+      if (metaTag?.$?.N === "datasource/modificationDate") {
+        date = getDate.iso8601Extended(parseInt(metaTag?.$?.V));
+      }
+    })
+  }
+
+  // Or try <MT N="mes:date" />
+  if (!date && result?.MT?.length > 0) {
+    result?.MT?.forEach((metaTag) => {
+      if (metaTag?.$?.N === "mes:date") {
+        date = getDate.iso8601Extended(parseInt(metaTag?.$?.V));
+      }
+    })
+  }
+
+  if (date) {
+    return <p className="date"><strong>Published date:</strong> {date}</p>;
+  }
+
+  return null;
+}

--- a/react-app/src/pages/Search/Result/index.js
+++ b/react-app/src/pages/Search/Result/index.js
@@ -65,6 +65,17 @@ const StyledResult = styled.div`
 `;
 
 function Result({ isDateShown, result, tab }) {
+  function getResultText() {
+    return (
+      <div className="text">
+        {result?.$?.MIME && getResultFileIcon(result)}
+        {getResultTitle(result, tab)}
+        {isDateShown && getResultDate(result)}
+        {getResultDescription(result, tab)}
+      </div>
+    );
+  }
+
   return (
     <StyledResult>
       {/*
@@ -75,21 +86,11 @@ function Result({ isDateShown, result, tab }) {
 
       <MediaQuery maxWidth={"575px"}>
         <div className="thumbnail"></div>
-        <div className="text">
-          {result?.$?.MIME && getResultFileIcon(result)}
-          {getResultTitle(result, tab)}
-          {isDateShown && getResultDate(result)}
-          {getResultDescription(result, tab)}
-        </div>
+        {getResultText()}
       </MediaQuery>
 
       <MediaQuery minWidth={"576px"}>
-        <div className="text">
-          {result?.$?.MIME && getResultFileIcon(result)}
-          {getResultTitle(result, tab)}
-          {isDateShown && getResultDate(result)}
-          {getResultDescription(result, tab)}
-        </div>
+        {getResultText()}
         <div className="thumbnail"></div>
       </MediaQuery>
     </StyledResult>

--- a/react-app/src/pages/Search/Result/index.js
+++ b/react-app/src/pages/Search/Result/index.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import getResultFileIcon from "./getResultFileIcon";
 import getResultTitle from "./getResultTitle";
+import getResultDate from "./getResultDate";
 import getResultDescription from "./getResultDescription";
 
 const StyledResult = styled.div`
@@ -63,7 +64,7 @@ const StyledResult = styled.div`
   }
 `;
 
-function Result({ result, tab }) {
+function Result({ isDateShown, result, tab }) {
   return (
     <StyledResult>
       {/*
@@ -77,6 +78,7 @@ function Result({ result, tab }) {
         <div className="text">
           {result?.$?.MIME && getResultFileIcon(result)}
           {getResultTitle(result, tab)}
+          {isDateShown && getResultDate(result)}
           {getResultDescription(result, tab)}
         </div>
       </MediaQuery>
@@ -85,6 +87,7 @@ function Result({ result, tab }) {
         <div className="text">
           {result?.$?.MIME && getResultFileIcon(result)}
           {getResultTitle(result, tab)}
+          {isDateShown && getResultDate(result)}
           {getResultDescription(result, tab)}
         </div>
         <div className="thumbnail"></div>
@@ -94,8 +97,14 @@ function Result({ result, tab }) {
 }
 
 Result.propTypes = {
+  isDateShown: PropTypes.bool,
   result: PropTypes.object.isRequired, // GSA XML <R> object: https://www.google.com/support/enterprise/static/gsa/docs/admin/current/gsa_doc_set/xml_reference/results_format.html#1079005
   tab: PropTypes.number,
 };
+
+Result.defaultProps = {
+  isDateShown: false,
+  tab: 1,
+}
 
 export default Result;


### PR DESCRIPTION
This PR adds "published date" display functionality to the Search/Result component. The search appliance returns several equivalent "last modified" date fields, both in a pre-formatted `YYYY-MM-DD` form and as Unix millisecond timestamps. Handling is added for each (with preference for the pre-formatted options), and the output is used in the Search/Result component.

- `getDate()` utility function and tests are added (1ccbc50)
- `getResultDate()` function returns mark-up for the different date formats (752ff0d)
- `isDateShown` Boolean is added to the Search/Result component, with a call to `getResultDate()` when `true` (528ea74)
- To pass Travis-CI, the tests for `getDate()` needed an explicit timezone environment variable added to `.travis.yaml` so the tests run in the America/Pacific timezone, matching our mock test data (2a82418)

Also:
- The Search/FilterMenu reset button now closes all of the filter accordions when it is pressed (f6f46ee)
- Focus styling is added within Search/FilterMenu so keyboard navigation makes sense (7a532bb)
- The text portion of the Search/Result component is refactored into a function to DRY out the code (51f149a)