### PR TITLE
Search results can be filtered and sorted based on user input

### DIFF
--- a/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
+++ b/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
@@ -96,8 +96,11 @@ function DateRangePicker({
 }
 
 DateRangePicker.propTypes = {
+  id: PropTypes.string.isRequired,
   initialStartDate: PropTypes.number.isRequired,
   initialEndDate: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  reportDates: PropTypes.func.isRequired,
 };
 
 export default DateRangePicker;

--- a/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
+++ b/react-app/src/pages/Search/FilterMenu/DateRangePicker.js
@@ -44,8 +44,12 @@ function DateRangePicker({
   label,
   reportDates,
 }) {
-  const [startDate, setStartDate] = useState(initialStartDate || new Date());
-  const [endDate, setEndDate] = useState(initialEndDate || new Date());
+  const [startDate, setStartDate] = useState(
+    new Date(initialStartDate) || new Date()
+  );
+  const [endDate, setEndDate] = useState(
+    new Date(initialEndDate) || new Date()
+  );
 
   return (
     <StyledDateRangePicker>
@@ -92,8 +96,8 @@ function DateRangePicker({
 }
 
 DateRangePicker.propTypes = {
-  initialStartDate: PropTypes.instanceOf(Date),
-  initialEndDate: PropTypes.instanceOf(Date),
+  initialStartDate: PropTypes.number.isRequired,
+  initialEndDate: PropTypes.number.isRequired,
 };
 
 export default DateRangePicker;

--- a/react-app/src/pages/Search/filterResults.js
+++ b/react-app/src/pages/Search/filterResults.js
@@ -1,0 +1,45 @@
+/**
+ * Return a filtered subset of search results given configuration data for
+ * desired time span, desired sort order, desired facet categorization, and the
+ * current search tab through which the search was conducted.
+ * @param {array} results
+ * @param {number} tab
+ * @param {string} timeSelectValue
+ * @param {array} customDateRange
+ * @param {string} sortedBySelectValue
+ * @param {string} facetSelectValue
+ * @returns {array}
+ */
+function filterResults (
+  results,
+  tab,
+  timeSelectValue,
+  customDateRange,
+  sortedBySelectValue,
+  facetSelectValue,
+) {
+  if (sortedBySelectValue === "most-recent") {
+    return sortByMostRecent(results)
+  }
+
+  return sortByBestMatch(results);
+}
+
+// Order results based on the `bestMatchPosition` attribute that we assign in
+// Search based on their initial order
+function sortByBestMatch(results) {
+  return results.sort((a, b) => {
+    return a?.bestMatchPosition - b?.bestMatchPosition;
+  });
+}
+
+// Order results based on their Unix millisecond modification date timestamp
+function sortByMostRecent(results) {
+  return results.sort((a, b) => {
+    const unixMsA = a?.MT?.find(metaTag => metaTag?.$?.N === "datasource/modificationDate")?.$?.V;
+    const unixMsB = b?.MT?.find(metaTag => metaTag?.$?.N === "datasource/modificationDate")?.$?.V;
+    return unixMsB - unixMsA;
+  });
+}
+
+export default filterResults;

--- a/react-app/src/pages/Search/filterResults.js
+++ b/react-app/src/pages/Search/filterResults.js
@@ -18,11 +18,13 @@ function filterResults (
   sortedBySelectValue,
   facetSelectValue,
 ) {
+  const trimmedByDate = trimByDate(results, timeSelectValue, customDateRange);
+
   if (sortedBySelectValue === "most-recent") {
-    return sortByMostRecent(results)
+    return sortByMostRecent(trimmedByDate);
   }
 
-  return sortByBestMatch(results);
+  return sortByBestMatch(trimmedByDate);
 }
 
 // Order results based on the `bestMatchPosition` attribute that we assign in
@@ -40,6 +42,79 @@ function sortByMostRecent(results) {
     const unixMsB = b?.MT?.find(metaTag => metaTag?.$?.N === "datasource/modificationDate")?.$?.V;
     return unixMsB - unixMsA;
   });
+}
+
+function trimByDate(results, timeSelectValue, customDateRange) {
+  if (timeSelectValue === "anytime") {
+    return results;
+  }
+
+  if (timeSelectValue === "today") {
+    const twentyFourHoursAgo = new Date().getTime() - 24 * 60 * 60 * 1000;
+
+    return results.filter((result) => {
+      const resultDate = result.MT?.find(
+        (metaTag) => metaTag?.$?.N === "datasource/modificationDate"
+      )?.$?.V;
+
+      return resultDate >= twentyFourHoursAgo;
+    });
+  }
+
+  if (timeSelectValue === "past-7-days") {
+    const sevenDaysAgo = new Date().getTime() - 7 * 24 * 60 * 60 * 1000;
+
+    return results.filter((result) => {
+      const resultDate = result.MT?.find(
+        (metaTag) => metaTag?.$?.N === "datasource/modificationDate"
+      )?.$?.V;
+
+      return resultDate >= sevenDaysAgo;
+    });
+  }
+
+  if (timeSelectValue === "past-30-days") {
+    const thirtyDaysAgo = new Date().getTime() - 30 * 24 * 60 * 60 * 1000;
+
+    return results.filter((result) => {
+      const resultDate = result.MT?.find(
+        (metaTag) => metaTag?.$?.N === "datasource/modificationDate"
+      )?.$?.V;
+
+      return resultDate >= thirtyDaysAgo;
+    });
+  }
+
+  if (timeSelectValue === "past-90-days") {
+    const ninetyDaysAgo = new Date().getTime() - 90 * 24 * 60 * 60 * 1000;
+
+    return results.filter((result) => {
+      const resultDate = result.MT?.find(
+        (metaTag) => metaTag?.$?.N === "datasource/modificationDate"
+      )?.$?.V;
+
+      return resultDate >= ninetyDaysAgo;
+    });
+  }
+
+  if (timeSelectValue === "custom-range") {
+    console.log("customDateRange[0]: ", customDateRange[0]);
+    console.log("customDateRange[1]: ", customDateRange[1]);
+
+    const targetStart = new Date(customDateRange[0]).getTime();
+    const targetEnd = new Date(customDateRange[1]).getTime();
+
+    console.log("targetStart: ", targetStart);
+    console.log("targetEnd: ", targetEnd);
+
+    return results.filter((result) => {
+      const resultDate = result.MT?.find(
+        (metaTag) => metaTag?.$?.N === "datasource/modificationDate"
+      )?.$?.V;
+
+      return resultDate >= targetStart && resultDate <= targetEnd;
+    });
+  }
 }
 
 export default filterResults;

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -110,8 +110,8 @@ function Search() {
   const [timeSelectOpen, setTimeSelectOpen] = useState(false);
   const [timeSelectValue, setTimeSelectValue] = useState("anytime");
   const [customDateRange, setCustomDateRange] = useState([
-    new Date().getTime() - 24 * 60 * 60 * 1000,
-    new Date().getTime(),
+    parseInt(new Date().getTime() - 24 * 60 * 60 * 1000),
+    parseInt(new Date().getTime()),
   ]);
   const [sortedBySelectOpen, setSortedBySelectOpen] = useState(false);
   const [sortedBySelectValue, setSortedBySelectValue] = useState("best-match");

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -110,8 +110,8 @@ function Search() {
   const [timeSelectOpen, setTimeSelectOpen] = useState(false);
   const [timeSelectValue, setTimeSelectValue] = useState("anytime");
   const [customDateRange, setCustomDateRange] = useState([
-    new Date(),
-    new Date(),
+    new Date().getTime() - 24 * 60 * 60 * 1000,
+    new Date().getTime(),
   ]);
   const [sortedBySelectOpen, setSortedBySelectOpen] = useState(false);
   const [sortedBySelectValue, setSortedBySelectValue] = useState("best-match");
@@ -335,6 +335,7 @@ function Search() {
       )}
 
       {/* Count of results found */}
+      {/* TODO: Change verbage when results are being filtered. */}
       {resultsCount > 0 && (
         <p className="results-found">
           Showing 1-{new Intl.NumberFormat().format(lastResultShown)} of{" "}
@@ -352,7 +353,7 @@ function Search() {
           timeSelectValue,
           customDateRange,
           sortedBySelectValue,
-          facetSelectValue,
+          facetSelectValue
         ).map((result, index) => {
           return (
             <Result

--- a/react-app/src/pages/Search/index.js
+++ b/react-app/src/pages/Search/index.js
@@ -5,11 +5,14 @@ import { useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import xml2js from "xml2js";
 
-import TabMenu from "./TabMenu";
-import FilterMenu from "./FilterMenu";
 import LoadSpinner from "../../components/LoadSpinner";
-import Result from "./Result";
 import SearchBar from "../../components/SearchBar";
+
+import FilterMenu from "./FilterMenu";
+import Result from "./Result";
+import TabMenu from "./TabMenu";
+
+import filterResults from "./filterResults";
 
 const StyledSearchResults = styled.div`
   max-width: 768px;
@@ -173,7 +176,15 @@ function Search() {
             res?.GSP?.RES.length > 0 &&
             res?.GSP?.RES[0]?.R?.length > 0
           ) {
-            newResults = [...newResults, ...res?.GSP?.RES[0]?.R];
+            let incoming = res?.GSP?.RES[0]?.R;
+
+            incoming.forEach((result, index) => {
+              result.bestMatchPosition = parseInt(
+                newResults.length + index
+              );
+            });
+
+            newResults = [...newResults, ...incoming];
           }
 
           // Update the resultsCount
@@ -335,7 +346,14 @@ function Search() {
       {/* List of results if applicable */}
       {resultsCount > 0 &&
         results?.length > 0 &&
-        results.map((result, index) => {
+        filterResults(
+          results,
+          tab,
+          timeSelectValue,
+          customDateRange,
+          sortedBySelectValue,
+          facetSelectValue,
+        ).map((result, index) => {
           return (
             <Result
               key={`result-${index}`}


### PR DESCRIPTION
This PR wraps up the Search/FilterMenu component by connecting the user's selections in the UI to the results display through the `filterResults()` function.

- Search results can be ordered by "best match" (the order in which the search appliance delivers them) or most recent chronologically (2906653)
- The DateRangePicker component (within the Search/FilterMenu) opens up with a two day range (yesterday to today) with Unix millisecond timestamps (6f984c, a9ad8a3)
- Search results can be filtered based on date ranges for today, the last week, last month, last three months, or custom ranges (688b770)
- Search results can be filtered based on facet/category chosen by the user (e45a8fe) which behaves simliarly to production in that only one selection is allowed at a time
- The filterResults() function is broken into three logical functions for filtering based on facets, filtering based on time, and sorting (0217727). The order of these operations doesn't matter except for how long each function will take to complete based on the current results set.